### PR TITLE
0.2.4 Release - Support for Data Streams (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,123 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 25 March 2025
+
+### Dependencies
+
+| Package                   | Version      |
+| ------------------------- | ------------ |
+| @chainlink/contracts-ccip | 1.5.1-beta.0 |
+| @chainlink/contracts      | 1.3.0        |
+
+### Services
+
+- [x] Chainlink CCIP
+- [x] Chainlink CCIP v1.5
+- [x] Chainlink Data Feeds
+- [x] Chainlink Data Streams
+- [ ] Chainlink Automation
+- [ ] Chainlink VRF 2
+- [ ] Chainlink VRF 2.5
+
+### Added
+
+- Added full support for Data Streams by adding `DataStreamsLocalSimulator.sol`
+  (Foundry/Hardhat/Remix IDE local mode), `DataStreamsLocalSimulatorFork.sol`
+  (Foundry forked mode), `DataStreamsLocalSimulatorFork.js` (Hardhat forked
+  mode) and `MockReportGenerator.sol` & `MockReportGenerator.js` to mock
+  generating unverified reports by Data Streams DON for local modes in Foundry
+  and Hardhat respectively.
+- Instructions to install Chainlink Local using Soldeer
+
+### Changed
+
+- Bumped `@chainlink/contracts` to `1.3.0` version
+- Started returning raw Report structs from `generateReportV2`,
+  `generateReportV3` and`generateReportV4` functions alongside the
+  `signedReport` bytes blob which is already returned
+
+## [0.2.4-beta.1] - 24 February 2025
+
+### Dependencies
+
+| Package                   | Version      |
+| ------------------------- | ------------ |
+| @chainlink/contracts-ccip | 1.5.1-beta.0 |
+| @chainlink/contracts      | 1.3.0        |
+
+### Services
+
+- [x] Chainlink CCIP
+- [x] Chainlink CCIP v1.5
+- [x] Chainlink Data Feeds
+- [x] Chainlink Data Streams
+- [ ] Chainlink Automation
+- [ ] Chainlink VRF 2
+- [ ] Chainlink VRF 2.5
+
+### Changed
+
+- Fixed incorrect import path for `Math.sol` in `MockFeeManager.sol`
+
+## [0.2.4-beta.0] - 23 February 2025
+
+### Dependencies
+
+| Package                   | Version      |
+| ------------------------- | ------------ |
+| @chainlink/contracts-ccip | 1.5.1-beta.0 |
+| @chainlink/contracts      | 1.3.0        |
+
+### Services
+
+- [x] Chainlink CCIP
+- [x] Chainlink CCIP v1.5
+- [x] Chainlink Data Feeds
+- [x] Chainlink Data Streams
+- [ ] Chainlink Automation
+- [ ] Chainlink VRF 2
+- [ ] Chainlink VRF 2.5
+
+### Added
+
+- Instructions to install Chainlink Local using Soldeer
+
+### Changed
+
+- Bumped `@chainlink/contracts` to `1.3.0` version
+- Started returning raw Report structs from `generateReportV2`,
+  `generateReportV3` and`generateReportV4` functions alongside the
+  `signedReport` bytes blob which is already returned
+
+## [0.2.4-beta] - 10 December 2024
+
+### Dependencies
+
+| Package                   | Version      |
+| ------------------------- | ------------ |
+| @chainlink/contracts-ccip | 1.5.1-beta.0 |
+| @chainlink/contracts      | 1.1.1        |
+
+### Services
+
+- [x] Chainlink CCIP
+- [x] Chainlink CCIP v1.5
+- [x] Chainlink Data Feeds
+- [x] Chainlink Data Streams
+- [ ] Chainlink Automation
+- [ ] Chainlink VRF 2
+- [ ] Chainlink VRF 2.5
+
+### Added
+
+- Added full support for Data Streams by adding `DataStreamsLocalSimulator.sol`
+  (Foundry/Hardhat/Remix IDE local mode), `DataStreamsLocalSimulatorFork.sol`
+  (Foundry forked mode), `DataStreamsLocalSimulatorFork.js` (Hardhat forked
+  mode) and `MockReportGenerator.sol` & `MockReportGenerator.js` to mock
+  generating unverified reports by Data Streams DON for local modes in Foundry
+  and Hardhat respectively.
+
 ## [0.2.3] - 30 November 2024
 
 ### Dependencies
@@ -299,3 +416,10 @@ and this project adheres to
   https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.2-beta.1
 [0.2.2]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.2
 [0.2.3]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.3
+[0.2.4-beta]:
+  https://github.com/smartcontractkit/chainlink-local/releases/tag/0.2.4-beta
+[0.2.4-beta.0]:
+  https://github.com/smartcontractkit/chainlink-local/releases/tag/0.2.4-beta.0
+[0.2.4-beta.1]:
+  https://github.com/smartcontractkit/chainlink-local/releases/tag/0.2.4-beta.1
+[0.2.4]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.4

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ forge install smartcontractkit/chainlink-local
 
 and then set remappings to: `@chainlink/local/=lib/chainlink-local/` in either `remappings.txt` or `foundry.toml` file
 
+#### Foundry (soldeer)
+
+```
+forge soldeer install chainlink-local~v0.2.4-beta https://github.com/smartcontractkit/chainlink-local.git
+```
+Replace `v0.2.4-beta` with your desired version number.
+
 #### Hardhat (npm)
 
 ```

--- a/api_reference/solidity/data-streams/DataStreamsLocalSimulator.mdx
+++ b/api_reference/solidity/data-streams/DataStreamsLocalSimulator.mdx
@@ -1,0 +1,91 @@
+# Solidity API
+
+## DataStreamsLocalSimulator
+
+### s_mockVerifier
+
+```solidity
+contract MockVerifier s_mockVerifier
+```
+
+### s_mockVerifierProxy
+
+```solidity
+contract MockVerifierProxy s_mockVerifierProxy
+```
+
+### s_mockFeeManager
+
+```solidity
+contract MockFeeManager s_mockFeeManager
+```
+
+### s_mockRewardManager
+
+```solidity
+contract MockRewardManager s_mockRewardManager
+```
+
+### i_wrappedNative
+
+```solidity
+contract WETH9 i_wrappedNative
+```
+
+The wrapped native token instance
+
+### i_linkToken
+
+```solidity
+contract LinkToken i_linkToken
+```
+
+The LINK token instance
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### requestLinkFromFaucet
+
+```solidity
+function requestLinkFromFaucet(address to, uint256 amount) external returns (bool success)
+```
+
+Requests LINK tokens from the faucet. The provided amount of tokens are
+transferred to provided destination address.
+
+#### Parameters
+
+| Name   | Type    | Description                                        |
+| ------ | ------- | -------------------------------------------------- |
+| to     | address | - The address to which LINK tokens are to be sent. |
+| amount | uint256 | - The amount of LINK tokens to send.               |
+
+#### Return Values
+
+| Name    | Type | Description                                                                   |
+| ------- | ---- | ----------------------------------------------------------------------------- |
+| success | bool | - Returns `true` if the transfer of tokens was successful, otherwise `false`. |
+
+### configuration
+
+```solidity
+function configuration() public view returns (contract WETH9 wrappedNative_, contract LinkToken linkToken_, contract MockVerifier mockVerifier_, contract MockVerifierProxy mockVerifierProxy_, contract MockFeeManager mockFeeManager_, contract MockRewardManager mockRewardManager_)
+```
+
+@notice Returns configuration details for pre-deployed contracts and services
+needed for local Data Streams simulations.
+
+#### Return Values
+
+| Name                | Type                       | Description                         |
+| ------------------- | -------------------------- | ----------------------------------- |
+| wrappedNative\_     | contract WETH9             | - The wrapped native token.         |
+| linkToken\_         | contract LinkToken         | - The LINK token.                   |
+| mockVerifier\_      | contract MockVerifier      | - The mock verifier contract.       |
+| mockVerifierProxy\_ | contract MockVerifierProxy | - The mock verifier proxy contract. |
+| mockFeeManager\_    | contract MockFeeManager    | - The mock fee manager contract.    |
+| mockRewardManager\_ | contract MockRewardManager | - The mock reward manager contract. |

--- a/api_reference/solidity/data-streams/DataStreamsLocalSimulatorFork.mdx
+++ b/api_reference/solidity/data-streams/DataStreamsLocalSimulatorFork.mdx
@@ -1,0 +1,102 @@
+# Solidity API
+
+## DataStreamsLocalSimulatorFork
+
+### i_register
+
+```solidity
+contract Register i_register
+```
+
+The immutable register instance
+
+### LINK_FAUCET
+
+```solidity
+address LINK_FAUCET
+```
+
+The address of the LINK faucet
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+Constructor to initialize the contract
+
+### getNetworkDetails
+
+```solidity
+function getNetworkDetails(uint256 chainId) external view returns (struct Register.NetworkDetails)
+```
+
+Returns the default values for currently Data Streams supported networks. If
+network is not present or some of the values are changed, user can manually add
+new network details using the `setNetworkDetails` function.
+
+#### Parameters
+
+| Name    | Type    | Description                                                                   |
+| ------- | ------- | ----------------------------------------------------------------------------- |
+| chainId | uint256 | - The blockchain network chain ID. For example 11155111 for Ethereum Sepolia. |
+
+#### Return Values
+
+| Name | Type                           | Description                                                                                                                                                  |
+| ---- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [0]  | struct Register.NetworkDetails | networkDetails - The tuple containing: verifierProxyAddress - The address of the Verifier Proxy smart contract. linkAddress - The address of the LINK token. |
+
+### setNetworkDetails
+
+```solidity
+function setNetworkDetails(uint256 chainId, struct Register.NetworkDetails networkDetails) external
+```
+
+If network details are not present or some of the values are changed, user can
+manually add new network details using the `setNetworkDetails` function.
+
+#### Parameters
+
+| Name           | Type                           | Description                                                                                                                                   |
+| -------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| chainId        | uint256                        | - The blockchain network chain ID. For example 11155111 for Ethereum Sepolia.                                                                 |
+| networkDetails | struct Register.NetworkDetails | - The tuple containing: verifierProxyAddress - The address of the Verifier Proxy smart contract. linkAddress - The address of the LINK token. |
+
+### requestLinkFromFaucet
+
+```solidity
+function requestLinkFromFaucet(address to, uint256 amount) external returns (bool success)
+```
+
+Requests LINK tokens from the faucet. The provided amount of tokens are
+transferred to provided destination address.
+
+#### Parameters
+
+| Name   | Type    | Description                                        |
+| ------ | ------- | -------------------------------------------------- |
+| to     | address | - The address to which LINK tokens are to be sent. |
+| amount | uint256 | - The amount of LINK tokens to send.               |
+
+#### Return Values
+
+| Name    | Type | Description                                                                   |
+| ------- | ---- | ----------------------------------------------------------------------------- |
+| success | bool | - Returns `true` if the transfer of tokens was successful, otherwise `false`. |
+
+### requestNativeFromFaucet
+
+```solidity
+function requestNativeFromFaucet(address to, uint256 amount) external
+```
+
+Requests native coints from the faucet.
+
+#### Parameters
+
+| Name   | Type    | Description                                         |
+| ------ | ------- | --------------------------------------------------- |
+| to     | address | - The address to which native coins are to be sent. |
+| amount | uint256 | - The amount of native coins to send.               |

--- a/api_reference/solidity/data-streams/MockFeeManager.mdx
+++ b/api_reference/solidity/data-streams/MockFeeManager.mdx
@@ -1,0 +1,159 @@
+# Solidity API
+
+## Common
+
+### Asset
+
+```solidity
+struct Asset {
+  address assetAddress;
+  uint256 amount;
+}
+```
+
+## MockFeeManager
+
+### Unauthorized
+
+```solidity
+error Unauthorized()
+```
+
+### InvalidAddress
+
+```solidity
+error InvalidAddress()
+```
+
+### InvalidQuote
+
+```solidity
+error InvalidQuote()
+```
+
+### ExpiredReport
+
+```solidity
+error ExpiredReport()
+```
+
+### InvalidDiscount
+
+```solidity
+error InvalidDiscount()
+```
+
+### InvalidSurcharge
+
+```solidity
+error InvalidSurcharge()
+```
+
+### InvalidDeposit
+
+```solidity
+error InvalidDeposit()
+```
+
+### i_linkAddress
+
+```solidity
+address i_linkAddress
+```
+
+### i_nativeAddress
+
+```solidity
+address i_nativeAddress
+```
+
+### i_proxyAddress
+
+```solidity
+address i_proxyAddress
+```
+
+### i_rewardManager
+
+```solidity
+contract IRewardManager i_rewardManager
+```
+
+### s_nativeSurcharge
+
+```solidity
+uint256 s_nativeSurcharge
+```
+
+### s_mockDiscounts
+
+```solidity
+mapping(address => uint256) s_mockDiscounts
+```
+
+### onlyProxy
+
+```solidity
+modifier onlyProxy()
+```
+
+### constructor
+
+```solidity
+constructor(address linkAddress, address nativeAddress, address proxyAddress, address rewardManager) public
+```
+
+### processFee
+
+```solidity
+function processFee(bytes payload, bytes parameterPayload, address subscriber) external payable
+```
+
+### processFeeBulk
+
+```solidity
+function processFeeBulk(bytes[] payloads, bytes parameterPayload, address subscriber) external payable
+```
+
+### getFeeAndReward
+
+```solidity
+function getFeeAndReward(address subscriber, bytes report, address quoteAddress) public view returns (struct Common.Asset, struct Common.Asset, uint256)
+```
+
+### \_processFee
+
+```solidity
+function _processFee(bytes payload, bytes parameterPayload, address subscriber) internal
+```
+
+### setNativeSurcharge
+
+```solidity
+function setNativeSurcharge(uint64 surcharge) external
+```
+
+### setMockDiscount
+
+```solidity
+function setMockDiscount(address subscriber, uint256 discount) external
+```
+
+### getMockDiscount
+
+```solidity
+function getMockDiscount(address subscriber) external view returns (uint256)
+```
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external pure returns (bool)
+```
+
+\_Returns true if this contract implements the interface defined by
+`interfaceId`. See the corresponding
+https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP
+section] to learn more about how these ids are created.
+
+This function call must use less than 30 000 gas.\_

--- a/api_reference/solidity/data-streams/MockReportGenerator.mdx
+++ b/api_reference/solidity/data-streams/MockReportGenerator.mdx
@@ -1,0 +1,171 @@
+# Solidity API
+
+## MockReportGenerator
+
+### i_donAddress
+
+```solidity
+address i_donAddress
+```
+
+### i_donDigest
+
+```solidity
+uint256 i_donDigest
+```
+
+### i_reportV2MockFeedId
+
+```solidity
+bytes32 i_reportV2MockFeedId
+```
+
+### i_reportV3MockFeedId
+
+```solidity
+bytes32 i_reportV3MockFeedId
+```
+
+### i_reportV4MockFeedId
+
+```solidity
+bytes32 i_reportV4MockFeedId
+```
+
+### s_price
+
+```solidity
+int192 s_price
+```
+
+### s_bid
+
+```solidity
+int192 s_bid
+```
+
+### s_ask
+
+```solidity
+int192 s_ask
+```
+
+### s_expiresPeriod
+
+```solidity
+uint32 s_expiresPeriod
+```
+
+### s_marketStatus
+
+```solidity
+uint32 s_marketStatus
+```
+
+### s_nativeFee
+
+```solidity
+uint192 s_nativeFee
+```
+
+### s_linkFee
+
+```solidity
+uint192 s_linkFee
+```
+
+### MockReportGenerator\_\_InvalidBid
+
+```solidity
+error MockReportGenerator__InvalidBid()
+```
+
+### MockReportGenerator\_\_InvalidAsk
+
+```solidity
+error MockReportGenerator__InvalidAsk()
+```
+
+### MockReportGenerator\_\_CastOverflow
+
+```solidity
+error MockReportGenerator__CastOverflow()
+```
+
+### constructor
+
+```solidity
+constructor(int192 initialPrice) public
+```
+
+### generateReport
+
+```solidity
+function generateReport(struct ReportVersions.ReportV2 report) external returns (bytes signedReport)
+```
+
+### generateReport
+
+```solidity
+function generateReport(struct ReportVersions.ReportV3 report) external returns (bytes signedReport)
+```
+
+### generateReport
+
+```solidity
+function generateReport(struct ReportVersions.ReportV4 report) external returns (bytes signedReport)
+```
+
+### generateReportV2
+
+```solidity
+function generateReportV2() external returns (bytes signedReport, struct ReportVersions.ReportV2 report)
+```
+
+### generateReportV3
+
+```solidity
+function generateReportV3() external returns (bytes signedReport, struct ReportVersions.ReportV3 report)
+```
+
+### generateReportV4
+
+```solidity
+function generateReportV4() external returns (bytes signedReport, struct ReportVersions.ReportV4 report)
+```
+
+### updatePrice
+
+```solidity
+function updatePrice(int192 price) public
+```
+
+### updatePriceBidAndAsk
+
+```solidity
+function updatePriceBidAndAsk(int192 price, int192 bid, int192 ask) external
+```
+
+### updateExpiresPeriod
+
+```solidity
+function updateExpiresPeriod(uint32 period) external
+```
+
+### updateMarketStatus
+
+```solidity
+function updateMarketStatus(uint32 status) external
+```
+
+### updateFees
+
+```solidity
+function updateFees(uint192 nativeFee, uint192 linkFee) external
+```
+
+### getMockDonAddress
+
+```solidity
+function getMockDonAddress() external view returns (address)
+```

--- a/api_reference/solidity/data-streams/MockRewardManager.mdx
+++ b/api_reference/solidity/data-streams/MockRewardManager.mdx
@@ -1,0 +1,70 @@
+# Solidity API
+
+## MockRewardManager
+
+### Unauthorized
+
+```solidity
+error Unauthorized()
+```
+
+### i_linkAddress
+
+```solidity
+address i_linkAddress
+```
+
+### s_feeManagerAddress
+
+```solidity
+address s_feeManagerAddress
+```
+
+### FeePaid
+
+```solidity
+event FeePaid(struct IRewardManager.FeePayment[] payments, address payer)
+```
+
+### onlyFeeManager
+
+```solidity
+modifier onlyFeeManager()
+```
+
+### constructor
+
+```solidity
+constructor(address linkAddress) public
+```
+
+### onFeePaid
+
+```solidity
+function onFeePaid(struct IRewardManager.FeePayment[] payments, address payer) external
+```
+
+### claimRewards
+
+```solidity
+function claimRewards(bytes32[]) external pure
+```
+
+### setFeeManager
+
+```solidity
+function setFeeManager(address newFeeManager) external
+```
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external pure returns (bool)
+```
+
+\_Returns true if this contract implements the interface defined by
+`interfaceId`. See the corresponding
+https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP
+section] to learn more about how these ids are created.
+
+This function call must use less than 30 000 gas.\_

--- a/api_reference/solidity/data-streams/MockVerifier.mdx
+++ b/api_reference/solidity/data-streams/MockVerifier.mdx
@@ -1,0 +1,142 @@
+# Solidity API
+
+## MockVerifier
+
+### AccessForbidden
+
+```solidity
+error AccessForbidden()
+```
+
+### InactiveFeed
+
+```solidity
+error InactiveFeed(bytes32 feedId)
+```
+
+### DigestInactive
+
+```solidity
+error DigestInactive(bytes32 feedId, bytes32 configDigest)
+```
+
+### BadVerification
+
+```solidity
+error BadVerification()
+```
+
+### InvalidV
+
+```solidity
+error InvalidV()
+```
+
+### AlreadyUsedSignature
+
+```solidity
+error AlreadyUsedSignature()
+```
+
+### InvalidSignatureLength
+
+```solidity
+error InvalidSignatureLength()
+```
+
+### InvalidS
+
+```solidity
+error InvalidS()
+```
+
+### N_2
+
+```solidity
+uint256 N_2
+```
+
+### MOCK_DATA_STREAM_DON_ADDRESS
+
+```solidity
+address MOCK_DATA_STREAM_DON_ADDRESS
+```
+
+### i_verifierProxy
+
+```solidity
+address i_verifierProxy
+```
+
+### s_inactiveDigests
+
+```solidity
+mapping(bytes32 => mapping(bytes32 => bool)) s_inactiveDigests
+```
+
+### s_inactiveFeeds
+
+```solidity
+mapping(bytes32 => bool) s_inactiveFeeds
+```
+
+### s_verifiedSignatures
+
+```solidity
+mapping(bytes => bool) s_verifiedSignatures
+```
+
+### ReportVerified
+
+```solidity
+event ReportVerified(bytes32 feedId, address sender)
+```
+
+### constructor
+
+```solidity
+constructor(address verifierProxy) public
+```
+
+### verify
+
+```solidity
+function verify(bytes signedReport, address sender) external returns (bytes verifierResponse)
+```
+
+### deactivateConfig
+
+```solidity
+function deactivateConfig(bytes32 feedId, bytes32 configDigest) external
+```
+
+### activateConfig
+
+```solidity
+function activateConfig(bytes32 feedId, bytes32 configDigest) external
+```
+
+### deactivateFeed
+
+```solidity
+function deactivateFeed(bytes32 feedId) external
+```
+
+### activateFeed
+
+```solidity
+function activateFeed(bytes32 feedId) external
+```
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external pure returns (bool)
+```
+
+\_Returns true if this contract implements the interface defined by
+`interfaceId`. See the corresponding
+https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP
+section] to learn more about how these ids are created.
+
+This function call must use less than 30 000 gas.\_

--- a/api_reference/solidity/data-streams/MockVerifierProxy.mdx
+++ b/api_reference/solidity/data-streams/MockVerifierProxy.mdx
@@ -1,0 +1,81 @@
+# Solidity API
+
+## MockVerifierProxy
+
+### ZeroAddress
+
+```solidity
+error ZeroAddress()
+```
+
+### VerifierInvalid
+
+```solidity
+error VerifierInvalid()
+```
+
+### VerifierNotFound
+
+```solidity
+error VerifierNotFound()
+```
+
+### s_verifier
+
+```solidity
+address s_verifier
+```
+
+### s_feeManager
+
+```solidity
+contract IVerifierFeeManager s_feeManager
+```
+
+### VerifierInitialized
+
+```solidity
+event VerifierInitialized(address verifierAddress)
+```
+
+### onlyValidVerifier
+
+```solidity
+modifier onlyValidVerifier(address verifierAddress)
+```
+
+### verify
+
+```solidity
+function verify(bytes payload, bytes parameterPayload) external payable returns (bytes)
+```
+
+### verifyBulk
+
+```solidity
+function verifyBulk(bytes[] payloads, bytes parameterPayload) external payable returns (bytes[] verifiedReports)
+```
+
+### \_verify
+
+```solidity
+function _verify(bytes payload) internal returns (bytes)
+```
+
+### initializeVerifier
+
+```solidity
+function initializeVerifier(address verifierAddress) external
+```
+
+### getVerifier
+
+```solidity
+function getVerifier(bytes32) external view returns (address)
+```
+
+### setFeeManager
+
+```solidity
+function setFeeManager(contract IVerifierFeeManager feeManager) external
+```

--- a/api_reference/solidity/data-streams/Register.mdx
+++ b/api_reference/solidity/data-streams/Register.mdx
@@ -1,0 +1,67 @@
+# Solidity API
+
+## Register
+
+This contract allows storing and retrieving network details for various chains.
+
+_Stores network details in a mapping based on chain IDs._
+
+### NetworkDetails
+
+```solidity
+struct NetworkDetails {
+  address verifierProxyAddress;
+  address linkAddress;
+}
+```
+
+### s_networkDetails
+
+```solidity
+mapping(uint256 => struct Register.NetworkDetails) s_networkDetails
+```
+
+Mapping to store network details based on chain ID.
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+Constructor to initialize the network details for various chains.
+
+### getNetworkDetails
+
+```solidity
+function getNetworkDetails(uint256 chainId) external view returns (struct Register.NetworkDetails networkDetails)
+```
+
+Retrieves network details for a given chain ID.
+
+#### Parameters
+
+| Name    | Type    | Description                                   |
+| ------- | ------- | --------------------------------------------- |
+| chainId | uint256 | - The ID of the chain to get the details for. |
+
+#### Return Values
+
+| Name           | Type                           | Description                                       |
+| -------------- | ------------------------------ | ------------------------------------------------- |
+| networkDetails | struct Register.NetworkDetails | - The network details for the specified chain ID. |
+
+### setNetworkDetails
+
+```solidity
+function setNetworkDetails(uint256 chainId, struct Register.NetworkDetails networkDetails) external
+```
+
+Sets the network details for a given chain ID.
+
+#### Parameters
+
+| Name           | Type                           | Description                                              |
+| -------------- | ------------------------------ | -------------------------------------------------------- |
+| chainId        | uint256                        | - The ID of the chain to set the details for.            |
+| networkDetails | struct Register.NetworkDetails | - The network details to set for the specified chain ID. |

--- a/api_reference/solidity/data-streams/ReportVersions.mdx
+++ b/api_reference/solidity/data-streams/ReportVersions.mdx
@@ -1,0 +1,67 @@
+# Solidity API
+
+## ReportVersions
+
+### ReportV2
+
+_Represents a data report from a Data Streams stream for v2 schema (crypto
+streams). The `price` value is carried to either 8 or 18 decimal places,
+depending on the stream. For more information, see
+https://docs.chain.link/data-streams/crypto-streams and
+https://docs.chain.link/data-streams/reference/report-schema_
+
+```solidity
+struct ReportV2 {
+  bytes32 feedId;
+  uint32 validFromTimestamp;
+  uint32 observationsTimestamp;
+  uint192 nativeFee;
+  uint192 linkFee;
+  uint32 expiresAt;
+  int192 benchmarkPrice;
+}
+```
+
+### ReportV3
+
+_Represents a data report from a Data Streams stream for v3 schema (crypto
+streams). The `price`, `bid`, and `ask` values are carried to either 8 or 18
+decimal places, depending on the stream. For more information, see
+https://docs.chain.link/data-streams/crypto-streams and
+https://docs.chain.link/data-streams/reference/report-schema_
+
+```solidity
+struct ReportV3 {
+  bytes32 feedId;
+  uint32 validFromTimestamp;
+  uint32 observationsTimestamp;
+  uint192 nativeFee;
+  uint192 linkFee;
+  uint32 expiresAt;
+  int192 price;
+  int192 bid;
+  int192 ask;
+}
+```
+
+### ReportV4
+
+_Represents a data report from a Data Streams stream for v4 schema (RWA stream).
+The `price` value is carried to either 8 or 18 decimal places, depending on the
+stream. The `marketStatus` indicates whether the market is currently open.
+Possible values: `0` (`Unknown`), `1` (`Closed`), `2` (`Open`). For more
+information, see https://docs.chain.link/data-streams/rwa-streams and
+https://docs.chain.link/data-streams/reference/report-schema-v4_
+
+```solidity
+struct ReportV4 {
+  bytes32 feedId;
+  uint32 validFromTimestamp;
+  uint32 observationsTimestamp;
+  uint192 nativeFee;
+  uint192 linkFee;
+  uint32 expiresAt;
+  int192 price;
+  uint32 marketStatus;
+}
+```

--- a/api_reference/solidity/data-streams/index.mdx
+++ b/api_reference/solidity/data-streams/index.mdx
@@ -1,0 +1,12 @@
+# Data-streams API Reference
+
+- [DataStreamsLocalSimulator](DataStreamsLocalSimulator.mdx)
+- [DataStreamsLocalSimulatorFork](DataStreamsLocalSimulatorFork.mdx)
+- [MockFeeManager](MockFeeManager.mdx)
+- [MockReportGenerator](MockReportGenerator.mdx)
+- [MockRewardManager](MockRewardManager.mdx)
+- [MockVerifier](MockVerifier.mdx)
+- [MockVerifierProxy](MockVerifierProxy.mdx)
+- [Register](Register.mdx)
+- [ReportVersions](ReportVersions.mdx)
+- [interfaces](interfaces/index.mdx)

--- a/api_reference/solidity/data-streams/interfaces/IRewardManager.mdx
+++ b/api_reference/solidity/data-streams/interfaces/IRewardManager.mdx
@@ -1,0 +1,30 @@
+# Solidity API
+
+## IRewardManager
+
+### onFeePaid
+
+```solidity
+function onFeePaid(struct IRewardManager.FeePayment[] payments, address payee) external
+```
+
+### claimRewards
+
+```solidity
+function claimRewards(bytes32[] poolIds) external
+```
+
+### setFeeManager
+
+```solidity
+function setFeeManager(address newFeeManager) external
+```
+
+### FeePayment
+
+```solidity
+struct FeePayment {
+  bytes32 poolId;
+  uint192 amount;
+}
+```

--- a/api_reference/solidity/data-streams/interfaces/IVerifier.mdx
+++ b/api_reference/solidity/data-streams/interfaces/IVerifier.mdx
@@ -1,0 +1,33 @@
+# Solidity API
+
+## IVerifier
+
+### verify
+
+```solidity
+function verify(bytes signedReport, address sender) external returns (bytes verifierResponse)
+```
+
+### activateConfig
+
+```solidity
+function activateConfig(bytes32 feedId, bytes32 configDigest) external
+```
+
+### deactivateConfig
+
+```solidity
+function deactivateConfig(bytes32 feedId, bytes32 configDigest) external
+```
+
+### activateFeed
+
+```solidity
+function activateFeed(bytes32 feedId) external
+```
+
+### deactivateFeed
+
+```solidity
+function deactivateFeed(bytes32 feedId) external
+```

--- a/api_reference/solidity/data-streams/interfaces/IVerifierFeeManager.mdx
+++ b/api_reference/solidity/data-streams/interfaces/IVerifierFeeManager.mdx
@@ -1,0 +1,15 @@
+# Solidity API
+
+## IVerifierFeeManager
+
+### processFee
+
+```solidity
+function processFee(bytes payload, bytes parameterPayload, address subscriber) external payable
+```
+
+### processFeeBulk
+
+```solidity
+function processFeeBulk(bytes[] payloads, bytes parameterPayload, address subscriber) external payable
+```

--- a/api_reference/solidity/data-streams/interfaces/index.mdx
+++ b/api_reference/solidity/data-streams/interfaces/index.mdx
@@ -1,0 +1,5 @@
+# Interfaces API Reference
+
+- [IRewardManager](IRewardManager.mdx)
+- [IVerifier](IVerifier.mdx)
+- [IVerifierFeeManager](IVerifierFeeManager.mdx)

--- a/api_reference/solidity/index.mdx
+++ b/api_reference/solidity/index.mdx
@@ -2,4 +2,5 @@
 
 - [ccip](ccip/index.mdx)
 - [data-feeds](data-feeds/index.mdx)
+- [data-streams](data-streams/index.mdx)
 - [shared](shared/index.mdx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@chainlink/local",
-  "version": "0.2.2",
+  "version": "0.2.4-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/local",
-      "version": "0.2.2",
+      "version": "0.2.4-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@chainlink/contracts": "^1.1.1",
+        "@chainlink/contracts": "^1.3.0",
         "@chainlink/contracts-ccip": "^1.5.1-beta.0"
       },
       "devDependencies": {
@@ -79,40 +79,6 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz",
       "integrity": "sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg=="
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-      "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/parser": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
@@ -143,17 +109,24 @@
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "node_modules/@chainlink/contracts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-1.1.1.tgz",
-      "integrity": "sha512-bAjusEonAqlaT0rndBIlcmYtI923p1r/OVqyd+NGtP0EpZmCJkOB8/I61xiUN3FIMC8IBZl68zYZdTiq/Y8MhQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-1.3.0.tgz",
+      "integrity": "sha512-Vk93nijTC5iRFW/L6FKUzeMuJy7k5dNzAtqlHpdreqtzL7efO/qXbYCkqjJFNXGurfOXVehHlehFoH4tWvSbfw==",
       "dependencies": {
-        "@changesets/changelog-github": "^0.4.8",
-        "@changesets/cli": "~2.26.2",
+        "@arbitrum/nitro-contracts": "1.1.1",
+        "@arbitrum/token-bridge-contracts": "1.1.2",
+        "@changesets/changelog-github": "^0.5.0",
+        "@changesets/cli": "~2.27.8",
         "@eth-optimism/contracts": "0.6.0",
         "@openzeppelin/contracts": "4.9.3",
         "@openzeppelin/contracts-upgradeable": "4.9.3",
         "@scroll-tech/contracts": "0.1.0",
-        "semver": "^7.6.2"
+        "@zksync/contracts": "git+https://github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=9"
       }
     },
     "node_modules/@chainlink/contracts-ccip": {
@@ -178,238 +151,6 @@
         "pnpm": ">=9"
       }
     },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/apply-release-plan": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.4.tgz",
-      "integrity": "sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/config": "^3.0.2",
-        "@changesets/get-version-range-type": "^0.4.0",
-        "@changesets/git": "^3.0.0",
-        "@changesets/should-skip-package": "^0.1.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "detect-indent": "^6.0.0",
-        "fs-extra": "^7.0.1",
-        "lodash.startcase": "^4.4.0",
-        "outdent": "^0.5.0",
-        "prettier": "^2.7.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.3.tgz",
-      "integrity": "sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/should-skip-package": "^0.1.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "semver": "^7.5.3"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/changelog-git": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.0.tgz",
-      "integrity": "sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==",
-      "dependencies": {
-        "@changesets/types": "^6.0.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/changelog-github": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.0.tgz",
-      "integrity": "sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==",
-      "dependencies": {
-        "@changesets/get-github-info": "^0.6.0",
-        "@changesets/types": "^6.0.0",
-        "dotenv": "^8.1.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/cli": {
-      "version": "2.27.7",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.7.tgz",
-      "integrity": "sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/apply-release-plan": "^7.0.4",
-        "@changesets/assemble-release-plan": "^6.0.3",
-        "@changesets/changelog-git": "^0.2.0",
-        "@changesets/config": "^3.0.2",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/get-release-plan": "^4.0.3",
-        "@changesets/git": "^3.0.0",
-        "@changesets/logger": "^0.1.0",
-        "@changesets/pre": "^2.0.0",
-        "@changesets/read": "^0.6.0",
-        "@changesets/should-skip-package": "^0.1.0",
-        "@changesets/types": "^6.0.0",
-        "@changesets/write": "^0.3.1",
-        "@manypkg/get-packages": "^1.1.3",
-        "@types/semver": "^7.5.0",
-        "ansi-colors": "^4.1.3",
-        "chalk": "^2.1.0",
-        "ci-info": "^3.7.0",
-        "enquirer": "^2.3.0",
-        "external-editor": "^3.1.0",
-        "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
-        "mri": "^1.2.0",
-        "outdent": "^0.5.0",
-        "p-limit": "^2.2.0",
-        "preferred-pm": "^3.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
-        "spawndamnit": "^2.0.0",
-        "term-size": "^2.1.0"
-      },
-      "bin": {
-        "changeset": "bin.js"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/config": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.2.tgz",
-      "integrity": "sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==",
-      "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/logger": "^0.1.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.2"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/errors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
-      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
-      "dependencies": {
-        "extendable-error": "^0.1.5"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/get-dependents-graph": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.1.tgz",
-      "integrity": "sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==",
-      "dependencies": {
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "chalk": "^2.1.0",
-        "fs-extra": "^7.0.1",
-        "semver": "^7.5.3"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/get-github-info": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
-      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
-      "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/get-release-plan": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.3.tgz",
-      "integrity": "sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/assemble-release-plan": "^6.0.3",
-        "@changesets/config": "^3.0.2",
-        "@changesets/pre": "^2.0.0",
-        "@changesets/read": "^0.6.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/get-version-range-type": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
-      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/git": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
-      "integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.2",
-        "spawndamnit": "^2.0.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/logger": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
-      "integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
-      "dependencies": {
-        "chalk": "^2.1.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/parse": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.0.tgz",
-      "integrity": "sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==",
-      "dependencies": {
-        "@changesets/types": "^6.0.0",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/pre": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
-      "integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/types": "^6.0.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/read": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
-      "integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/git": "^3.0.0",
-        "@changesets/logger": "^0.1.0",
-        "@changesets/parse": "^0.4.0",
-        "@changesets/types": "^6.0.0",
-        "chalk": "^2.1.0",
-        "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
-      "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ=="
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/@changesets/write": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.1.tgz",
-      "integrity": "sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/types": "^6.0.0",
-        "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
-        "prettier": "^2.7.1"
-      }
-    },
     "node_modules/@chainlink/contracts-ccip/node_modules/@eth-optimism/contracts": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.6.0.tgz",
@@ -421,48 +162,6 @@
       },
       "peerDependencies": {
         "ethers": "^5"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@chainlink/contracts-ccip/node_modules/ethers": {
@@ -513,83 +212,6 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
-    "node_modules/@chainlink/contracts-ccip/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@chainlink/contracts-ccip/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -599,14 +221,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@chainlink/contracts-ccip/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/@chainlink/contracts/node_modules/@eth-optimism/contracts": {
@@ -671,9 +285,9 @@
       }
     },
     "node_modules/@chainlink/contracts/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -682,15 +296,15 @@
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
-      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.10.tgz",
+      "integrity": "sha512-wNyeIJ3yDsVspYvHnEz1xQDq18D9ifed3lI+wxRQRK4pArUcuHgCTrHv0QRnnwjhVCQACxZ+CBih3wgOct6UXw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/config": "^2.3.1",
-        "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^2.0.0",
-        "@changesets/types": "^5.2.1",
+        "@changesets/config": "^3.1.1",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.2",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
@@ -726,7 +340,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -746,9 +359,9 @@
       }
     },
     "node_modules/@changesets/apply-release-plan/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -765,22 +378,22 @@
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
-      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.6.tgz",
+      "integrity": "sha512-Frkj8hWJ1FRZiY3kzVCKzS0N5mMwWKwmv9vpam7vt8rZjLL1JMthdh6pSDVSPumHPshTTkKZ0VtNbE0cJHZZUg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "semver": "^7.5.3"
       }
     },
     "node_modules/@changesets/assemble-release-plan/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -789,20 +402,20 @@
       }
     },
     "node_modules/@changesets/changelog-git": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
-      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
       "dependencies": {
-        "@changesets/types": "^5.2.1"
+        "@changesets/types": "^6.1.0"
       }
     },
     "node_modules/@changesets/changelog-github": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.8.tgz",
-      "integrity": "sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
       "dependencies": {
-        "@changesets/get-github-info": "^0.5.2",
-        "@changesets/types": "^5.2.1",
+        "@changesets/get-github-info": "^0.6.0",
+        "@changesets/types": "^6.1.0",
         "dotenv": "^8.1.0"
       }
     },
@@ -815,43 +428,38 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
-      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
+      "version": "2.27.12",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.12.tgz",
+      "integrity": "sha512-9o3fOfHYOvBnyEn0mcahB7wzaA3P4bGJf8PNqGit5PKaMEFdsRixik+txkrJWd2VX+O6wRFXpxQL8j/1ANKE9g==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/apply-release-plan": "^6.1.4",
-        "@changesets/assemble-release-plan": "^5.2.4",
-        "@changesets/changelog-git": "^0.1.14",
-        "@changesets/config": "^2.3.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/get-release-plan": "^3.0.17",
-        "@changesets/git": "^2.0.0",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.14",
-        "@changesets/read": "^0.5.9",
-        "@changesets/types": "^5.2.1",
-        "@changesets/write": "^0.2.3",
+        "@changesets/apply-release-plan": "^7.0.8",
+        "@changesets/assemble-release-plan": "^6.0.5",
+        "@changesets/changelog-git": "^0.2.0",
+        "@changesets/config": "^3.0.5",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.2",
+        "@changesets/get-release-plan": "^4.0.6",
+        "@changesets/git": "^3.0.2",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.1",
+        "@changesets/read": "^0.6.2",
+        "@changesets/should-skip-package": "^0.1.1",
+        "@changesets/types": "^6.0.0",
+        "@changesets/write": "^0.3.2",
         "@manypkg/get-packages": "^1.1.3",
-        "@types/is-ci": "^3.0.0",
-        "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
-        "chalk": "^2.1.0",
-        "enquirer": "^2.3.0",
+        "ci-info": "^3.7.0",
+        "enquirer": "^2.4.1",
         "external-editor": "^3.1.0",
         "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
-        "is-ci": "^3.0.1",
-        "meow": "^6.0.0",
-        "outdent": "^0.5.0",
+        "mri": "^1.2.0",
         "p-limit": "^2.2.0",
-        "preferred-pm": "^3.0.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3",
-        "spawndamnit": "^2.0.0",
-        "term-size": "^2.1.0",
-        "tty-table": "^4.1.5"
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
       },
       "bin": {
         "changeset": "bin.js"
@@ -882,17 +490,6 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@changesets/cli/node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/@changesets/cli/node_modules/jsonfile": {
@@ -934,9 +531,9 @@
       }
     },
     "node_modules/@changesets/cli/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -953,17 +550,17 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
-      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==",
       "dependencies": {
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.8"
       }
     },
     "node_modules/@changesets/config/node_modules/fs-extra": {
@@ -996,50 +593,28 @@
       }
     },
     "node_modules/@changesets/errors": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.1.4.tgz",
-      "integrity": "sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
       "dependencies": {
         "extendable-error": "^0.1.5"
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
-      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
+      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
       "dependencies": {
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
-        "chalk": "^2.1.0",
-        "fs-extra": "^7.0.1",
+        "picocolors": "^1.1.0",
         "semver": "^7.5.3"
       }
     },
-    "node_modules/@changesets/get-dependents-graph/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@changesets/get-dependents-graph/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@changesets/get-dependents-graph/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1047,70 +622,59 @@
         "node": ">=10"
       }
     },
-    "node_modules/@changesets/get-dependents-graph/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@changesets/get-github-info": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.2.tgz",
-      "integrity": "sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
       "dependencies": {
         "dataloader": "^1.4.0",
         "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
-      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.8.tgz",
+      "integrity": "sha512-MM4mq2+DQU1ZT7nqxnpveDMTkMBLnwNX44cX7NSxlXmr7f8hO6/S2MXNiXG54uf/0nYnefv0cfy4Czf/ZL/EKQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/assemble-release-plan": "^5.2.4",
-        "@changesets/config": "^2.3.1",
-        "@changesets/pre": "^1.0.14",
-        "@changesets/read": "^0.5.9",
-        "@changesets/types": "^5.2.1",
+        "@changesets/assemble-release-plan": "^6.0.6",
+        "@changesets/config": "^3.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.3",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
     "node_modules/@changesets/get-version-range-type": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz",
-      "integrity": "sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
     },
     "node_modules/@changesets/git": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
-      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.2.tgz",
+      "integrity": "sha512-r1/Kju9Y8OxRRdvna+nxpQIsMsRQn9dhhAZt94FLDeu0Hij2hnOozW8iqnHBgvu+KdnJppCveQwK4odwfw/aWQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.2",
-        "spawndamnit": "^2.0.0"
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
       }
     },
     "node_modules/@changesets/logger": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.0.5.tgz",
-      "integrity": "sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
       "dependencies": {
-        "chalk": "^2.1.0"
+        "picocolors": "^1.1.0"
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
-      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.1.tgz",
+      "integrity": "sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==",
       "dependencies": {
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.1.0",
         "js-yaml": "^3.13.1"
       }
     },
@@ -1147,13 +711,12 @@
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
-      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       }
@@ -1188,18 +751,17 @@
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
-      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.3.tgz",
+      "integrity": "sha512-9H4p/OuJ3jXEUTjaVGdQEhBdqoT2cO5Ts95JTFsQyawmKzpL8FnIeJSyhTDPW1MBRDnwZlHFEM9SpPwJDY5wIg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/git": "^2.0.0",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.16",
-        "@changesets/types": "^5.2.1",
-        "chalk": "^2.1.0",
+        "@changesets/git": "^3.0.2",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.1",
+        "@changesets/types": "^6.1.0",
         "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0"
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
       }
     },
     "node_modules/@changesets/read/node_modules/fs-extra": {
@@ -1232,32 +794,25 @@
       }
     },
     "node_modules/@changesets/should-skip-package": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.0.tgz",
-      "integrity": "sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/types": "^6.0.0",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
-    "node_modules/@changesets/should-skip-package/node_modules/@changesets/types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
-      "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ=="
-    },
     "node_modules/@changesets/types": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
-      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="
     },
     "node_modules/@changesets/write": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
-      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.2.tgz",
+      "integrity": "sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.0.0",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
         "prettier": "^2.7.1"
@@ -1288,7 +843,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -3941,28 +3495,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/is-ci": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.4.tgz",
-      "integrity": "sha512-AkCYCmwlXeuH89DagDCzvCAyltI2v9lh3U3DqSg/GrBYoReAaWwxfXCqMx9UV5MajLZ4ZFwZzV4cABGIxk2XRw==",
-      "dependencies": {
-        "ci-info": "^3.1.0"
-      }
-    },
-    "node_modules/@types/is-ci/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@types/jsdoc-to-markdown": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/jsdoc-to-markdown/-/jsdoc-to-markdown-7.0.6.tgz",
@@ -4017,11 +3549,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/@types/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
-    },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
@@ -4036,11 +3563,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
@@ -4071,11 +3593,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -4299,6 +3816,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -4348,27 +3866,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "devOptional": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -4384,14 +3886,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/asap": {
@@ -4450,6 +3944,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "devOptional": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -4672,22 +4167,14 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/breakword": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/breakword/-/breakword-1.0.6.tgz",
-      "integrity": "sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==",
-      "dependencies": {
-        "wcwidth": "^1.0.1"
       }
     },
     "node_modules/brorand": {
@@ -4837,6 +4324,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "devOptional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4860,30 +4348,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/caseless": {
@@ -5122,14 +4586,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/collect-all": {
@@ -5512,39 +4968,11 @@
         "node": "*"
       }
     },
-    "node_modules/csv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
-      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
-      "dependencies": {
-        "csv-generate": "^3.4.3",
-        "csv-parse": "^4.16.3",
-        "csv-stringify": "^5.6.5",
-        "stream-transform": "^2.1.3"
-      },
-      "engines": {
-        "node": ">= 0.1.90"
-      }
-    },
-    "node_modules/csv-generate": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
-      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
-    },
-    "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
-    },
-    "node_modules/csv-stringify": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
-      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -5561,6 +4989,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -5577,6 +5006,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -5628,37 +5058,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -5686,21 +5085,11 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "devOptional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -5717,6 +5106,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "devOptional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -5940,18 +5330,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "node_modules/es-abstract": {
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "devOptional": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -6011,6 +5394,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -6022,6 +5406,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6030,6 +5415,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "devOptional": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -6041,6 +5427,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -6054,6 +5441,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "devOptional": true,
       "dependencies": {
         "hasown": "^2.0.0"
       }
@@ -6062,6 +5450,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "devOptional": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -6529,9 +5918,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -6570,15 +5959,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "node_modules/find-yarn-workspace-root2": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
-      "integrity": "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==",
-      "dependencies": {
-        "micromatch": "^4.0.2",
-        "pkg-dir": "^4.2.0"
-      }
-    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -6610,6 +5990,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "devOptional": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -6784,6 +6165,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6792,6 +6174,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -6809,6 +6192,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6833,6 +6217,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "devOptional": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -6861,6 +6246,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -6949,6 +6335,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "devOptional": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -6983,6 +6370,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -6994,11 +6382,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -7029,14 +6412,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/hardhat": {
@@ -7226,6 +6601,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7242,6 +6618,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "devOptional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -7253,6 +6630,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7264,6 +6642,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7275,6 +6654,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -7311,6 +6691,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -7342,11 +6723,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/http-basic": {
       "version": "8.1.3",
@@ -7489,6 +6865,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "devOptional": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -7520,6 +6897,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -7531,15 +6909,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "devOptional": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -7562,6 +6936,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7577,6 +6952,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7599,6 +6975,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "devOptional": true,
       "dependencies": {
         "is-typed-array": "^1.1.13"
       },
@@ -7613,6 +6990,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7677,6 +7055,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7696,6 +7075,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7718,6 +7098,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7733,6 +7114,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -7747,6 +7129,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7772,6 +7155,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -7786,6 +7170,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "devOptional": true,
       "dependencies": {
         "which-typed-array": "^1.1.14"
       },
@@ -7811,6 +7196,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -7870,11 +7256,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -8050,11 +7431,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -8135,6 +7511,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8145,14 +7523,6 @@
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "dependencies": {
         "graceful-fs": "^4.1.11"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -8169,11 +7539,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -8182,52 +7547,6 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/load-yaml-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
-      "integrity": "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.13.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/load-yaml-file/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/load-yaml-file/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/locate-path": {
@@ -8393,17 +7712,6 @@
       "devOptional": true,
       "peer": true
     },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -8478,69 +7786,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/meow": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/meow/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8557,11 +7802,11 @@
       "peer": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -8585,14 +7830,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -8624,27 +7861,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/minimist-options/node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -8653,14 +7869,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mixme": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.10.tgz",
-      "integrity": "sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q==",
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/mkdirp": {
@@ -9017,25 +8225,6 @@
         "nopt": "bin/nopt.js"
       }
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9087,6 +8276,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9095,6 +8285,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9113,6 +8304,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -9262,29 +8454,17 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.9.tgz",
+      "integrity": "sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q=="
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/patch-package": {
       "version": "6.5.1",
@@ -9518,9 +8698,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9541,166 +8721,13 @@
         "node": ">=6"
       }
     },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/preferred-pm": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.3.tgz",
-      "integrity": "sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==",
-      "dependencies": {
-        "find-up": "^5.0.0",
-        "find-yarn-workspace-root2": "1.2.16",
-        "path-exists": "^4.0.0",
-        "which-pm": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/prelude-ls": {
@@ -9758,11 +8785,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -9826,14 +8848,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9854,116 +8868,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/read-yaml-file": {
@@ -10060,18 +8964,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/reduce-extract": {
@@ -10197,6 +9089,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -10251,11 +9144,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/requizzle": {
       "version": "0.2.4",
@@ -10421,6 +9309,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -10437,7 +9326,8 @@
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "devOptional": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -10462,6 +9352,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -10625,15 +9516,11 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-    },
     "node_modules/set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
       "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "devOptional": true,
       "dependencies": {
         "define-data-property": "^1.1.2",
         "es-errors": "^1.3.0",
@@ -10650,6 +9537,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "devOptional": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -10737,6 +9625,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
       "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -10861,196 +9750,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/smartwrap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-2.0.2.tgz",
-      "integrity": "sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==",
-      "dependencies": {
-        "array.prototype.flat": "^1.2.3",
-        "breakword": "^1.0.5",
-        "grapheme-splitter": "^1.0.4",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1",
-        "yargs": "^15.1.0"
-      },
-      "bin": {
-        "smartwrap": "src/terminal-adapter.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/smartwrap/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/smartwrap/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/smartwrap/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/smartwrap/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/smartwrap/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/smartwrap/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/smartwrap/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/smartwrap/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/smartwrap/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/smartwrap/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smartwrap/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/solc": {
       "version": "0.8.26",
@@ -11274,65 +9973,78 @@
       }
     },
     "node_modules/spawndamnit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
-      "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
       "dependencies": {
-        "cross-spawn": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
       }
     },
     "node_modules/spawndamnit/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "node_modules/spawndamnit/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+    "node_modules/spawndamnit/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/spawndamnit/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
-    },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+    "node_modules/spawndamnit/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+    "node_modules/spawndamnit/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ=="
+    "node_modules/spawndamnit/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spawndamnit/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/split-ca": {
       "version": "1.0.1",
@@ -11421,14 +10133,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stream-transform": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
-      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
-      "dependencies": {
-        "mixme": "^0.5.1"
-      }
-    },
     "node_modules/stream-via": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
@@ -11487,6 +10191,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -11504,6 +10209,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -11517,6 +10223,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -11572,17 +10279,6 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -11851,14 +10547,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ts-command-line-args": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
@@ -12027,128 +10715,6 @@
       "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
       "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw=="
     },
-    "node_modules/tty-table": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.3.tgz",
-      "integrity": "sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "csv": "^5.5.3",
-        "kleur": "^4.1.5",
-        "smartwrap": "^2.0.2",
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.1",
-        "yargs": "^17.7.1"
-      },
-      "bin": {
-        "tty-table": "adapters/terminal-adapter.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/tty-table/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/tty-table/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/tty-table/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tty-table/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/tty-table/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/tty-table/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tty-table/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tty-table/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tty-table/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -12306,6 +10872,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -12319,6 +10886,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -12337,6 +10905,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -12356,6 +10925,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -12423,6 +10993,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -12507,15 +11078,6 @@
       "devOptional": true,
       "peer": true
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/walk-back": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
@@ -12524,14 +11086,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/web3-utils": {
@@ -12622,6 +11176,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "devOptional": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -12633,35 +11188,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
-    },
-    "node_modules/which-pm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.0.0.tgz",
-      "integrity": "sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==",
-      "dependencies": {
-        "load-yaml-file": "^0.2.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.15"
-      }
-    },
-    "node_modules/which-pm/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -13014,31 +11545,6 @@
         }
       }
     },
-    "@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-      "requires": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
-    },
-    "@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      }
-    },
     "@babel/parser": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
@@ -13059,17 +11565,20 @@
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "@chainlink/contracts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-1.1.1.tgz",
-      "integrity": "sha512-bAjusEonAqlaT0rndBIlcmYtI923p1r/OVqyd+NGtP0EpZmCJkOB8/I61xiUN3FIMC8IBZl68zYZdTiq/Y8MhQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-1.3.0.tgz",
+      "integrity": "sha512-Vk93nijTC5iRFW/L6FKUzeMuJy7k5dNzAtqlHpdreqtzL7efO/qXbYCkqjJFNXGurfOXVehHlehFoH4tWvSbfw==",
       "requires": {
-        "@changesets/changelog-github": "^0.4.8",
-        "@changesets/cli": "~2.26.2",
+        "@arbitrum/nitro-contracts": "1.1.1",
+        "@arbitrum/token-bridge-contracts": "1.1.2",
+        "@changesets/changelog-github": "^0.5.0",
+        "@changesets/cli": "~2.27.8",
         "@eth-optimism/contracts": "0.6.0",
         "@openzeppelin/contracts": "4.9.3",
         "@openzeppelin/contracts-upgradeable": "4.9.3",
         "@scroll-tech/contracts": "0.1.0",
-        "semver": "^7.6.2"
+        "@zksync/contracts": "git+https://github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
+        "semver": "^7.6.3"
       },
       "dependencies": {
         "@eth-optimism/contracts": {
@@ -13121,9 +11630,9 @@
           }
         },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         }
       }
     },
@@ -13145,235 +11654,6 @@
         "semver": "^7.6.3"
       },
       "dependencies": {
-        "@changesets/apply-release-plan": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.4.tgz",
-          "integrity": "sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/config": "^3.0.2",
-            "@changesets/get-version-range-type": "^0.4.0",
-            "@changesets/git": "^3.0.0",
-            "@changesets/should-skip-package": "^0.1.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "detect-indent": "^6.0.0",
-            "fs-extra": "^7.0.1",
-            "lodash.startcase": "^4.4.0",
-            "outdent": "^0.5.0",
-            "prettier": "^2.7.1",
-            "resolve-from": "^5.0.0",
-            "semver": "^7.5.3"
-          }
-        },
-        "@changesets/assemble-release-plan": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.3.tgz",
-          "integrity": "sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/errors": "^0.2.0",
-            "@changesets/get-dependents-graph": "^2.1.1",
-            "@changesets/should-skip-package": "^0.1.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "semver": "^7.5.3"
-          }
-        },
-        "@changesets/changelog-git": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.0.tgz",
-          "integrity": "sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==",
-          "requires": {
-            "@changesets/types": "^6.0.0"
-          }
-        },
-        "@changesets/changelog-github": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.0.tgz",
-          "integrity": "sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==",
-          "requires": {
-            "@changesets/get-github-info": "^0.6.0",
-            "@changesets/types": "^6.0.0",
-            "dotenv": "^8.1.0"
-          }
-        },
-        "@changesets/cli": {
-          "version": "2.27.7",
-          "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.7.tgz",
-          "integrity": "sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/apply-release-plan": "^7.0.4",
-            "@changesets/assemble-release-plan": "^6.0.3",
-            "@changesets/changelog-git": "^0.2.0",
-            "@changesets/config": "^3.0.2",
-            "@changesets/errors": "^0.2.0",
-            "@changesets/get-dependents-graph": "^2.1.1",
-            "@changesets/get-release-plan": "^4.0.3",
-            "@changesets/git": "^3.0.0",
-            "@changesets/logger": "^0.1.0",
-            "@changesets/pre": "^2.0.0",
-            "@changesets/read": "^0.6.0",
-            "@changesets/should-skip-package": "^0.1.0",
-            "@changesets/types": "^6.0.0",
-            "@changesets/write": "^0.3.1",
-            "@manypkg/get-packages": "^1.1.3",
-            "@types/semver": "^7.5.0",
-            "ansi-colors": "^4.1.3",
-            "chalk": "^2.1.0",
-            "ci-info": "^3.7.0",
-            "enquirer": "^2.3.0",
-            "external-editor": "^3.1.0",
-            "fs-extra": "^7.0.1",
-            "human-id": "^1.0.2",
-            "mri": "^1.2.0",
-            "outdent": "^0.5.0",
-            "p-limit": "^2.2.0",
-            "preferred-pm": "^3.0.0",
-            "resolve-from": "^5.0.0",
-            "semver": "^7.5.3",
-            "spawndamnit": "^2.0.0",
-            "term-size": "^2.1.0"
-          }
-        },
-        "@changesets/config": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.2.tgz",
-          "integrity": "sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==",
-          "requires": {
-            "@changesets/errors": "^0.2.0",
-            "@changesets/get-dependents-graph": "^2.1.1",
-            "@changesets/logger": "^0.1.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "fs-extra": "^7.0.1",
-            "micromatch": "^4.0.2"
-          }
-        },
-        "@changesets/errors": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
-          "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
-          "requires": {
-            "extendable-error": "^0.1.5"
-          }
-        },
-        "@changesets/get-dependents-graph": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.1.tgz",
-          "integrity": "sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==",
-          "requires": {
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "chalk": "^2.1.0",
-            "fs-extra": "^7.0.1",
-            "semver": "^7.5.3"
-          }
-        },
-        "@changesets/get-github-info": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
-          "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
-          "requires": {
-            "dataloader": "^1.4.0",
-            "node-fetch": "^2.5.0"
-          }
-        },
-        "@changesets/get-release-plan": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.3.tgz",
-          "integrity": "sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/assemble-release-plan": "^6.0.3",
-            "@changesets/config": "^3.0.2",
-            "@changesets/pre": "^2.0.0",
-            "@changesets/read": "^0.6.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3"
-          }
-        },
-        "@changesets/get-version-range-type": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
-          "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
-        },
-        "@changesets/git": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
-          "integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/errors": "^0.2.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "is-subdir": "^1.1.1",
-            "micromatch": "^4.0.2",
-            "spawndamnit": "^2.0.0"
-          }
-        },
-        "@changesets/logger": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
-          "integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
-          "requires": {
-            "chalk": "^2.1.0"
-          }
-        },
-        "@changesets/parse": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.0.tgz",
-          "integrity": "sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==",
-          "requires": {
-            "@changesets/types": "^6.0.0",
-            "js-yaml": "^3.13.1"
-          }
-        },
-        "@changesets/pre": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
-          "integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/errors": "^0.2.0",
-            "@changesets/types": "^6.0.0",
-            "@manypkg/get-packages": "^1.1.3",
-            "fs-extra": "^7.0.1"
-          }
-        },
-        "@changesets/read": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
-          "integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/git": "^3.0.0",
-            "@changesets/logger": "^0.1.0",
-            "@changesets/parse": "^0.4.0",
-            "@changesets/types": "^6.0.0",
-            "chalk": "^2.1.0",
-            "fs-extra": "^7.0.1",
-            "p-filter": "^2.1.0"
-          }
-        },
-        "@changesets/types": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
-          "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ=="
-        },
-        "@changesets/write": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.1.tgz",
-          "integrity": "sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==",
-          "requires": {
-            "@babel/runtime": "^7.20.1",
-            "@changesets/types": "^6.0.0",
-            "fs-extra": "^7.0.1",
-            "human-id": "^1.0.2",
-            "prettier": "^2.7.1"
-          }
-        },
         "@eth-optimism/contracts": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.6.0.tgz",
@@ -13383,29 +11663,6 @@
             "@ethersproject/abstract-provider": "^5.7.0",
             "@ethersproject/abstract-signer": "^5.7.0"
           }
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "ci-info": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
-        },
-        "dotenv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "ethers": {
           "version": "5.7.2",
@@ -13445,78 +11702,23 @@
             "@ethersproject/wordlists": "5.7.0"
           }
         },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "prettier": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-        },
         "semver": {
           "version": "7.6.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
           "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
     "@changesets/apply-release-plan": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
-      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.10.tgz",
+      "integrity": "sha512-wNyeIJ3yDsVspYvHnEz1xQDq18D9ifed3lI+wxRQRK4pArUcuHgCTrHv0QRnnwjhVCQACxZ+CBih3wgOct6UXw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/config": "^2.3.1",
-        "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^2.0.0",
-        "@changesets/types": "^5.2.1",
+        "@changesets/config": "^3.1.1",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.2",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
@@ -13556,9 +11758,9 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
         },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         },
         "universalify": {
           "version": "0.1.2",
@@ -13568,40 +11770,40 @@
       }
     },
     "@changesets/assemble-release-plan": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
-      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.6.tgz",
+      "integrity": "sha512-Frkj8hWJ1FRZiY3kzVCKzS0N5mMwWKwmv9vpam7vt8rZjLL1JMthdh6pSDVSPumHPshTTkKZ0VtNbE0cJHZZUg==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "semver": "^7.5.3"
       },
       "dependencies": {
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         }
       }
     },
     "@changesets/changelog-git": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
-      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
       "requires": {
-        "@changesets/types": "^5.2.1"
+        "@changesets/types": "^6.1.0"
       }
     },
     "@changesets/changelog-github": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.8.tgz",
-      "integrity": "sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
       "requires": {
-        "@changesets/get-github-info": "^0.5.2",
-        "@changesets/types": "^5.2.1",
+        "@changesets/get-github-info": "^0.6.0",
+        "@changesets/types": "^6.1.0",
         "dotenv": "^8.1.0"
       },
       "dependencies": {
@@ -13613,43 +11815,38 @@
       }
     },
     "@changesets/cli": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
-      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
+      "version": "2.27.12",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.12.tgz",
+      "integrity": "sha512-9o3fOfHYOvBnyEn0mcahB7wzaA3P4bGJf8PNqGit5PKaMEFdsRixik+txkrJWd2VX+O6wRFXpxQL8j/1ANKE9g==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/apply-release-plan": "^6.1.4",
-        "@changesets/assemble-release-plan": "^5.2.4",
-        "@changesets/changelog-git": "^0.1.14",
-        "@changesets/config": "^2.3.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/get-release-plan": "^3.0.17",
-        "@changesets/git": "^2.0.0",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.14",
-        "@changesets/read": "^0.5.9",
-        "@changesets/types": "^5.2.1",
-        "@changesets/write": "^0.2.3",
+        "@changesets/apply-release-plan": "^7.0.8",
+        "@changesets/assemble-release-plan": "^6.0.5",
+        "@changesets/changelog-git": "^0.2.0",
+        "@changesets/config": "^3.0.5",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.2",
+        "@changesets/get-release-plan": "^4.0.6",
+        "@changesets/git": "^3.0.2",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.1",
+        "@changesets/read": "^0.6.2",
+        "@changesets/should-skip-package": "^0.1.1",
+        "@changesets/types": "^6.0.0",
+        "@changesets/write": "^0.3.2",
         "@manypkg/get-packages": "^1.1.3",
-        "@types/is-ci": "^3.0.0",
-        "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
-        "chalk": "^2.1.0",
-        "enquirer": "^2.3.0",
+        "ci-info": "^3.7.0",
+        "enquirer": "^2.4.1",
         "external-editor": "^3.1.0",
         "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
-        "is-ci": "^3.0.1",
-        "meow": "^6.0.0",
-        "outdent": "^0.5.0",
+        "mri": "^1.2.0",
         "p-limit": "^2.2.0",
-        "preferred-pm": "^3.0.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3",
-        "spawndamnit": "^2.0.0",
-        "term-size": "^2.1.0",
-        "tty-table": "^4.1.5"
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
       },
       "dependencies": {
         "ci-info": {
@@ -13665,14 +11862,6 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
-          }
-        },
-        "is-ci": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-          "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-          "requires": {
-            "ci-info": "^3.2.0"
           }
         },
         "jsonfile": {
@@ -13702,9 +11891,9 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
         },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         },
         "universalify": {
           "version": "0.1.2",
@@ -13714,17 +11903,17 @@
       }
     },
     "@changesets/config": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
-      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==",
       "requires": {
-        "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.6",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.8"
       },
       "dependencies": {
         "fs-extra": {
@@ -13753,111 +11942,84 @@
       }
     },
     "@changesets/errors": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.1.4.tgz",
-      "integrity": "sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
       "requires": {
         "extendable-error": "^0.1.5"
       }
     },
     "@changesets/get-dependents-graph": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
-      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
+      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
       "requires": {
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
-        "chalk": "^2.1.0",
-        "fs-extra": "^7.0.1",
+        "picocolors": "^1.1.0",
         "semver": "^7.5.3"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         }
       }
     },
     "@changesets/get-github-info": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.2.tgz",
-      "integrity": "sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
       "requires": {
         "dataloader": "^1.4.0",
         "node-fetch": "^2.5.0"
       }
     },
     "@changesets/get-release-plan": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
-      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.8.tgz",
+      "integrity": "sha512-MM4mq2+DQU1ZT7nqxnpveDMTkMBLnwNX44cX7NSxlXmr7f8hO6/S2MXNiXG54uf/0nYnefv0cfy4Czf/ZL/EKQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/assemble-release-plan": "^5.2.4",
-        "@changesets/config": "^2.3.1",
-        "@changesets/pre": "^1.0.14",
-        "@changesets/read": "^0.5.9",
-        "@changesets/types": "^5.2.1",
+        "@changesets/assemble-release-plan": "^6.0.6",
+        "@changesets/config": "^3.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.3",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
     "@changesets/get-version-range-type": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz",
-      "integrity": "sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="
     },
     "@changesets/git": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
-      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.2.tgz",
+      "integrity": "sha512-r1/Kju9Y8OxRRdvna+nxpQIsMsRQn9dhhAZt94FLDeu0Hij2hnOozW8iqnHBgvu+KdnJppCveQwK4odwfw/aWQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.2",
-        "spawndamnit": "^2.0.0"
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
       }
     },
     "@changesets/logger": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.0.5.tgz",
-      "integrity": "sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
       "requires": {
-        "chalk": "^2.1.0"
+        "picocolors": "^1.1.0"
       }
     },
     "@changesets/parse": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
-      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.1.tgz",
+      "integrity": "sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==",
       "requires": {
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.1.0",
         "js-yaml": "^3.13.1"
       },
       "dependencies": {
@@ -13886,13 +12048,12 @@
       }
     },
     "@changesets/pre": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
-      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.2.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       },
@@ -13923,18 +12084,17 @@
       }
     },
     "@changesets/read": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
-      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.3.tgz",
+      "integrity": "sha512-9H4p/OuJ3jXEUTjaVGdQEhBdqoT2cO5Ts95JTFsQyawmKzpL8FnIeJSyhTDPW1MBRDnwZlHFEM9SpPwJDY5wIg==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/git": "^2.0.0",
-        "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.16",
-        "@changesets/types": "^5.2.1",
-        "chalk": "^2.1.0",
+        "@changesets/git": "^3.0.2",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.1",
+        "@changesets/types": "^6.1.0",
         "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0"
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -13963,34 +12123,25 @@
       }
     },
     "@changesets/should-skip-package": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.0.tgz",
-      "integrity": "sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/types": "^6.0.0",
+        "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3"
-      },
-      "dependencies": {
-        "@changesets/types": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
-          "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ=="
-        }
       }
     },
     "@changesets/types": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
-      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="
     },
     "@changesets/write": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
-      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.2.tgz",
+      "integrity": "sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/types": "^5.2.1",
+        "@changesets/types": "^6.0.0",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
         "prettier": "^2.7.1"
@@ -15886,21 +14037,6 @@
         "@types/node": "*"
       }
     },
-    "@types/is-ci": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.4.tgz",
-      "integrity": "sha512-AkCYCmwlXeuH89DagDCzvCAyltI2v9lh3U3DqSg/GrBYoReAaWwxfXCqMx9UV5MajLZ4ZFwZzV4cABGIxk2XRw==",
-      "requires": {
-        "ci-info": "^3.1.0"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
-        }
-      }
-    },
     "@types/jsdoc-to-markdown": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/jsdoc-to-markdown/-/jsdoc-to-markdown-7.0.6.tgz",
@@ -15950,11 +14086,6 @@
       "dev": true,
       "peer": true
     },
-    "@types/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
-    },
     "@types/mocha": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
@@ -15969,11 +14100,6 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
-    },
-    "@types/normalize-package-data": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "@types/pbkdf2": {
       "version": "3.1.2",
@@ -16004,11 +14130,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -16170,6 +14291,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -16201,21 +14323,11 @@
         "es-shim-unscopables": "^1.0.2"
       }
     },
-    "array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
     "arraybuffer.prototype.slice": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "devOptional": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -16226,11 +14338,6 @@
         "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
       }
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
     },
     "asap": {
       "version": "2.0.6",
@@ -16278,6 +14385,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "devOptional": true,
       "requires": {
         "possible-typed-array-names": "^1.0.0"
       }
@@ -16444,19 +14552,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "breakword": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/breakword/-/breakword-1.0.6.tgz",
-      "integrity": "sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==",
-      "requires": {
-        "wcwidth": "^1.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "brorand": {
@@ -16577,6 +14677,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "devOptional": true,
       "requires": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -16589,23 +14690,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
-    },
-    "camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        }
-      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -16787,11 +14871,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
     "collect-all": {
       "version": "1.0.4",
@@ -17105,36 +15184,11 @@
       "dev": true,
       "peer": true
     },
-    "csv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
-      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
-      "requires": {
-        "csv-generate": "^3.4.3",
-        "csv-parse": "^4.16.3",
-        "csv-stringify": "^5.6.5",
-        "stream-transform": "^2.1.3"
-      }
-    },
-    "csv-generate": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
-      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
-    },
-    "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
-    },
-    "csv-stringify": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
-      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
-    },
     "data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -17145,6 +15199,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -17155,6 +15210,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -17186,27 +15242,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
     },
-    "decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="
-        }
-      }
-    },
     "deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -17228,18 +15263,11 @@
       "dev": true,
       "peer": true
     },
-    "defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "requires": {
-        "clone": "^1.0.2"
-      }
-    },
     "define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "devOptional": true,
       "requires": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -17250,6 +15278,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "devOptional": true,
       "requires": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -17415,18 +15444,11 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "es-abstract": {
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "devOptional": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -17480,6 +15502,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "devOptional": true,
       "requires": {
         "get-intrinsic": "^1.2.4"
       }
@@ -17487,12 +15510,14 @@
     "es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "devOptional": true
     },
     "es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "devOptional": true,
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -17501,6 +15526,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "devOptional": true,
       "requires": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -17511,6 +15537,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "devOptional": true,
       "requires": {
         "hasown": "^2.0.0"
       }
@@ -17519,6 +15546,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "devOptional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -17888,9 +15916,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -17920,15 +15948,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "find-yarn-workspace-root2": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
-      "integrity": "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==",
-      "requires": {
-        "micromatch": "^4.0.2",
-        "pkg-dir": "^4.2.0"
-      }
-    },
     "flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -17943,6 +15962,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "devOptional": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -18063,12 +16083,14 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "devOptional": true
     },
     "function.prototype.name": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -18079,7 +16101,8 @@
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "devOptional": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -18095,6 +16118,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "devOptional": true,
       "requires": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -18114,6 +16138,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -18178,6 +16203,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "devOptional": true,
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -18203,6 +16229,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "devOptional": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -18211,11 +16238,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "handlebars": {
       "version": "4.7.8",
@@ -18237,11 +16259,6 @@
           "dev": true
         }
       }
-    },
-    "hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
     },
     "hardhat": {
       "version": "2.22.13",
@@ -18375,7 +16392,8 @@
     "has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "devOptional": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -18386,6 +16404,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "devOptional": true,
       "requires": {
         "es-define-property": "^1.0.0"
       }
@@ -18393,17 +16412,20 @@
     "has-proto": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "devOptional": true
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "devOptional": true
     },
     "has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.3"
       }
@@ -18431,6 +16453,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -18456,11 +16479,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "http-basic": {
       "version": "8.1.3",
@@ -18573,6 +16591,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "devOptional": true,
       "requires": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -18598,20 +16617,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "devOptional": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -18628,6 +16644,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18636,7 +16653,8 @@
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "devOptional": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -18650,6 +16668,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "devOptional": true,
       "requires": {
         "is-typed-array": "^1.1.13"
       }
@@ -18658,6 +16677,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18693,7 +16713,8 @@
     "is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "devOptional": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -18704,6 +16725,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18717,6 +16739,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18726,6 +16749,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7"
       }
@@ -18734,6 +16758,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18750,6 +16775,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -18758,6 +16784,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "devOptional": true,
       "requires": {
         "which-typed-array": "^1.1.14"
       }
@@ -18771,6 +16798,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18812,11 +16840,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -18950,11 +16973,6 @@
         }
       }
     },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
-    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -19013,7 +17031,9 @@
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "peer": true
     },
     "klaw-sync": {
       "version": "6.0.0",
@@ -19022,11 +17042,6 @@
       "requires": {
         "graceful-fs": "^4.1.11"
       }
-    },
-    "kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "levn": {
       "version": "0.3.0",
@@ -19039,11 +17054,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
     "linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -19051,41 +17061,6 @@
       "dev": true,
       "requires": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "load-yaml-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
-      "integrity": "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==",
-      "requires": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.13.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "locate-path": {
@@ -19221,11 +17196,6 @@
       "devOptional": true,
       "peer": true
     },
-    "map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
-    },
     "markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -19281,50 +17251,6 @@
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="
     },
-    "meow": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
-      "requires": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-        },
-        "type-fest": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -19338,11 +17264,11 @@
       "peer": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -19358,11 +17284,6 @@
       "requires": {
         "mime-db": "1.52.0"
       }
-    },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -19387,33 +17308,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
-    "minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
-        }
-      }
-    },
     "minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
-    },
-    "mixme": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.10.tgz",
-      "integrity": "sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q=="
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -19672,24 +17571,6 @@
         "abbrev": "1"
       }
     },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-        }
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -19731,12 +17612,14 @@
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "devOptional": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "devOptional": true
     },
     "object-to-spawn-args": {
       "version": "2.0.1",
@@ -19748,6 +17631,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -19859,23 +17743,17 @@
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "dev": true
     },
+    "package-manager-detector": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.9.tgz",
+      "integrity": "sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q=="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
       "dev": true,
       "peer": true
-    },
-    "parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      }
     },
     "patch-package": {
       "version": "6.5.1",
@@ -20038,9 +17916,9 @@
       }
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -20052,114 +17930,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
-    "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "requires": {
-        "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        }
-      }
-    },
     "possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
-    },
-    "preferred-pm": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.3.tgz",
-      "integrity": "sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==",
-      "requires": {
-        "find-up": "^5.0.0",
-        "find-yarn-workspace-root2": "1.2.16",
-        "path-exists": "^4.0.0",
-        "which-pm": "2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        }
-      }
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "devOptional": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -20204,11 +17979,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
-    },
     "pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -20244,11 +18014,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -20266,84 +18031,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "requires": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "requires": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-        }
       }
     },
     "read-yaml-file": {
@@ -20417,15 +18104,6 @@
       "peer": true,
       "requires": {
         "minimatch": "^3.0.5"
-      }
-    },
-    "redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "requires": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
       }
     },
     "reduce-extract": {
@@ -20522,6 +18200,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -20558,11 +18237,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requizzle": {
       "version": "0.2.4",
@@ -20671,6 +18345,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -20681,7 +18356,8 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "devOptional": true
         }
       }
     },
@@ -20694,6 +18370,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -20826,15 +18503,11 @@
         "randombytes": "^2.1.0"
       }
     },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-    },
     "set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
       "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "devOptional": true,
       "requires": {
         "define-data-property": "^1.1.2",
         "es-errors": "^1.3.0",
@@ -20848,6 +18521,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "devOptional": true,
       "requires": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -20914,6 +18588,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
       "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -21000,147 +18675,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
-    "smartwrap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-2.0.2.tgz",
-      "integrity": "sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==",
-      "requires": {
-        "array.prototype.flat": "^1.2.3",
-        "breakword": "^1.0.5",
-        "grapheme-splitter": "^1.0.4",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1",
-        "yargs": "^15.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },
@@ -21322,67 +18856,56 @@
       }
     },
     "spawndamnit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
-      "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
       "requires": {
-        "cross-spawn": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "shebang-regex": "^3.0.0"
           }
         },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
-    },
-    "spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ=="
     },
     "split-ca": {
       "version": "1.0.1",
@@ -21451,14 +18974,6 @@
         }
       }
     },
-    "stream-transform": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
-      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
-      "requires": {
-        "mixme": "^0.5.1"
-      }
-    },
     "stream-via": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
@@ -21505,6 +19020,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -21516,6 +19032,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -21526,6 +19043,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -21560,14 +19078,6 @@
       "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
       "requires": {
         "is-hex-prefixed": "1.0.0"
-      }
-    },
-    "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "requires": {
-        "min-indent": "^1.0.0"
       }
     },
     "strip-json-comments": {
@@ -21784,11 +19294,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
-    },
     "ts-command-line-args": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
@@ -21910,94 +19415,6 @@
       "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
       "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw=="
     },
-    "tty-table": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.3.tgz",
-      "integrity": "sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==",
-      "requires": {
-        "chalk": "^4.1.2",
-        "csv": "^5.5.3",
-        "kleur": "^4.1.5",
-        "smartwrap": "^2.0.2",
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.1",
-        "yargs": "^17.7.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yargs": {
-          "version": "17.7.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
-        }
-      }
-    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -22111,6 +19528,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -22121,6 +19539,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -22133,6 +19552,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "devOptional": true,
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -22146,6 +19566,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -22190,6 +19611,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -22258,28 +19680,11 @@
       "devOptional": true,
       "peer": true
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "walk-back": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
       "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
       "dev": true
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
     },
     "web3-utils": {
       "version": "1.10.4",
@@ -22356,6 +19761,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "devOptional": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -22364,31 +19770,11 @@
         "is-symbol": "^1.0.3"
       }
     },
-    "which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
-    },
-    "which-pm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.0.0.tgz",
-      "integrity": "sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==",
-      "requires": {
-        "load-yaml-file": "^0.2.0",
-        "path-exists": "^4.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        }
-      }
-    },
     "which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "devOptional": true,
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@chainlink/local",
   "description": "Chainlink Local Simulator",
   "license": "MIT",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "files": [
     "src/**/*.sol",
     "!src/test/**/*",
     "scripts/ccipLocalSimulatorFork.js",
+    "scripts/data-streams/**/*.js",
     "abi/**/*.json"
   ],
   "repository": {
@@ -42,7 +43,7 @@
     "solidity-docgen": "^0.6.0-beta.36"
   },
   "dependencies": {
-    "@chainlink/contracts": "^1.1.1",
+    "@chainlink/contracts": "^1.3.0",
     "@chainlink/contracts-ccip": "^1.5.1-beta.0"
   }
 }

--- a/scripts/data-streams/DataStreamsLocalSimulatorFork.js
+++ b/scripts/data-streams/DataStreamsLocalSimulatorFork.js
@@ -1,0 +1,37 @@
+const { ethers } = require("hardhat");
+const { setBalance } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+
+const LinkTokenAbi = require("../../abi/LinkToken.json");
+
+/**
+ * Requests LINK tokens from the faucet and returns the transaction hash
+ *
+ * @param {string} linkAddress The address of the LINK contract on the current network
+ * @param {string} to The address to send LINK to
+ * @param {bigint} amount The amount of LINK to request
+ * @returns {Promise<string>} Promise resolving to the transaction hash of the fund transfer
+ */
+async function requestLinkFromFaucet(linkAddress, to, amount) {
+    const LINK_FAUCET_ADDRESS = `0x4281eCF07378Ee595C564a59048801330f3084eE`;
+    const linkFaucetImpersonated = await ethers.getImpersonatedSigner(LINK_FAUCET_ADDRESS);
+
+    const linkToken = new ethers.Contract(linkAddress, LinkTokenAbi, ethers.provider);
+    const tx = await linkToken.connect(linkFaucetImpersonated).transfer(to, amount);
+
+    return tx.hash;
+}
+
+/**
+ * Requests native coins from the faucet
+ * 
+ * @param {string} to The address to send coins to
+ * @param {bigint} amount The amount of coins to request
+ */
+async function requestNativeFromFaucet(to, amount) {
+    await setBalance(to, amount);
+}
+
+module.exports = {
+    requestLinkFromFaucet,
+    requestNativeFromFaucet
+};

--- a/scripts/data-streams/MockReportGenerator.js
+++ b/scripts/data-streams/MockReportGenerator.js
@@ -1,0 +1,188 @@
+const { ethers } = require("hardhat");
+
+const { ReportV2, ReportV3, ReportV4 } = require("./ReportVersions");
+
+class MockReportGenerator {
+    #abi_encoder;
+
+    constructor(initialPrice) {
+        // uint256(keccak256(abi.encodePacked("Mock Data Streams DON")));
+        this.i_donDigest = BigInt(ethers.keccak256(ethers.toUtf8Bytes("Mock Data Streams DON")));
+        this.i_donAddress = ethers.computeAddress("0x" + this.i_donDigest.toString(16));
+
+        this.i_reportV2MockFeedId = "0x0002777777777777777777777777777777777777777777777777777777777777";
+        this.i_reportV3MockFeedId = "0x0003777777777777777777777777777777777777777777777777777777777777";
+        this.i_reportV4MockFeedId = "0x0004777777777777777777777777777777777777777777777777777777777777";
+
+        this.updatePrice(initialPrice);
+
+        this.s_expiresPeriod = 86400; // 1 day
+        this.s_marketStatus = 2; // 0 (Unknown), 1 (Closed), 2 (Open)
+        this.s_nativeFee = 0; // 0 by default
+        this.s_linkFee = 0; // 0 by default
+
+        this.#abi_encoder = ethers.AbiCoder.defaultAbiCoder();
+    }
+
+    generateReportV2WithData(report) {
+        const reportData = this.#abi_encoder.encode(["bytes32", "uint32", "uint32", "uint192", "uint192", "uint32", "int192"], [report.feedId, report.validFromTimestamp, report.observationsTimestamp, report.nativeFee, report.linkFee, report.expiresAt, report.benchmarkPrice]);
+        const signedReport = this.#signReport(reportData);
+        return signedReport;
+    }
+
+    generateReportV3WithData(report) {
+        const reportData = this.#abi_encoder.encode(["bytes32", "uint32", "uint32", "uint192", "uint192", "uint32", "int192", "int192", "int192"], [report.feedId, report.validFromTimestamp, report.observationsTimestamp, report.nativeFee, report.linkFee, report.expiresAt, report.price, report.bid, report.ask]);
+        const signedReport = this.#signReport(reportData);
+        return signedReport;
+    }
+
+    generateReportV4WithData(report) {
+        const reportData = this.#abi_encoder.encode(["bytes32", "uint32", "uint32", "uint192", "uint192", "uint32", "int192", "uint8"], [report.feedId, report.validFromTimestamp, report.observationsTimestamp, report.nativeFee, report.linkFee, report.expiresAt, report.price, report.marketStatus]);
+        const signedReport = this.#signReport(reportData);
+        return signedReport;
+    }
+
+    async generateReportV2() {
+        const latestBlock = await ethers.provider.getBlock("latest");
+        const currentTimestamp = latestBlock.timestamp;
+
+        const report = new ReportV2({
+            feedId: this.i_reportV2MockFeedId,
+            validFromTimestamp: currentTimestamp,
+            observationsTimestamp: currentTimestamp,
+            nativeFee: this.s_nativeFee,
+            linkFee: this.s_linkFee,
+            expiresAt: currentTimestamp + this.s_expiresPeriod,
+            benchmarkPrice: this.s_price,
+        });
+
+        const signedReport = this.generateReportV2WithData(report);
+
+        return { signedReport, report };
+    }
+
+    async generateReportV3() {
+        const latestBlock = await ethers.provider.getBlock("latest");
+        const currentTimestamp = latestBlock.timestamp;
+
+        const report = new ReportV3({
+            feedId: this.i_reportV3MockFeedId,
+            validFromTimestamp: currentTimestamp,
+            observationsTimestamp: currentTimestamp,
+            nativeFee: this.s_nativeFee,
+            linkFee: this.s_linkFee,
+            expiresAt: currentTimestamp + this.s_expiresPeriod,
+            price: this.s_price,
+            bid: this.s_bid,
+            ask: this.s_ask,
+        });
+
+        const signedReport = this.generateReportV3WithData(report);
+
+        return { signedReport, report };
+    }
+
+    async generateReportV4() {
+        const latestBlock = await ethers.provider.getBlock("latest");
+        const currentTimestamp = latestBlock.timestamp;
+
+        const report = new ReportV4({
+            feedId: this.i_reportV4MockFeedId,
+            validFromTimestamp: currentTimestamp,
+            observationsTimestamp: currentTimestamp,
+            nativeFee: this.s_nativeFee,
+            linkFee: this.s_linkFee,
+            expiresAt: currentTimestamp + this.s_expiresPeriod,
+            price: this.s_price,
+            marketStatus: this.s_marketStatus,
+        });
+
+        const signedReport = this.generateReportV4WithData(report);
+
+        return { signedReport, report };
+    }
+
+    updatePrice(price) {
+        let priceAdjusted;
+        let zeroOnePercent;
+        if (BigInt(price) === price) {
+            priceAdjusted = BigInt(price);
+            zeroOnePercent = BigInt(1000);
+        } else {
+            priceAdjusted = price;
+            zeroOnePercent = 1000;
+        }
+
+        this.s_price = priceAdjusted;
+        const delta = priceAdjusted / zeroOnePercent; // 0.1% = 1/1000
+        this.s_bid = priceAdjusted - delta;
+        this.s_ask = priceAdjusted + delta;
+    }
+
+    updatePriceBidAndAsk(price, bid, ask) {
+        // bid < price < ask
+        if (bid >= price) throw new Error("Bid must be less than price");
+        if (ask <= price) throw new Error("Ask must be greater than price");
+
+        this.s_price = price;
+        this.s_bid = bid;
+        this.s_ask = ask;
+    }
+
+    updateExpiresPeriod(period) {
+        this.s_expiresPeriod = period;
+    }
+
+    updateMarketStatus(status) {
+        this.s_marketStatus = status;
+    }
+
+    updateFees(nativeFee, linkFee) {
+        this.s_nativeFee = nativeFee;
+        this.s_linkFee = linkFee;
+    }
+
+    getMockDonAddress() {
+        return this.i_donAddress;
+    }
+
+    #signReport(reportData) {
+        const N_2 = "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0";
+
+        // Create reportContext (bytes32[3])
+        const reportContext = [
+            `0x${this.i_donDigest.toString(16)}`, // bytes32(i_donDigest)
+            `0x0000000000000000000000000000000000000000000000000000000000000000`, // not needed for mocks
+            `0x0000000000000000000000000000000000000000000000000000000000000000`, // not needed for mocks
+        ];
+
+        const hashedReport = ethers.keccak256(reportData);
+
+        const h = ethers.solidityPackedKeccak256(["bytes32", "bytes32[3]"], [hashedReport, reportContext]);
+
+        const signer = new ethers.SigningKey(`0x${this.i_donDigest.toString(16)}`);
+        let signature = signer.sign(h);
+
+        if (BigInt(signature.s) > BigInt(N_2)) {
+            const adjustedS = BigInt(N_2) - BigInt(signature.s);
+            signature = {
+                r: signature.r,
+                s: `0x${adjustedS.toString(16)}`,
+                v: 27
+            }
+        }
+
+        const rawRs = [signature.r];
+        const rawSs = [signature.s];
+        const rawVs = `0x00000000000000000000000000000000000000000000000000000000000000${BigInt(signature.v).toString(16)}`;
+
+        return this.#abi_encoder.encode(["bytes32[3]", "bytes", "bytes32[]", "bytes32[]", "bytes32"], [reportContext, reportData, rawRs, rawSs, rawVs]);
+    }
+}
+
+module.exports = {
+    ReportV2,
+    ReportV3,
+    ReportV4,
+    MockReportGenerator
+}

--- a/scripts/data-streams/ReportVersions.js
+++ b/scripts/data-streams/ReportVersions.js
@@ -1,0 +1,71 @@
+class ReportV2 {
+    constructor({
+        feedId,
+        validFromTimestamp,
+        observationsTimestamp,
+        nativeFee,
+        linkFee,
+        expiresAt,
+        benchmarkPrice,
+    }) {
+        this.feedId = feedId; // (bytes32) The feed ID the report has data for
+        this.validFromTimestamp = validFromTimestamp; // (uint32) Earliest timestamp for which price is applicable
+        this.observationsTimestamp = observationsTimestamp; // (uint32) Latest timestamp for which price is applicable
+        this.nativeFee = nativeFee; // (uint192) Base cost to validate a transaction using the report, denominated in the chain’s native token (WETH/ETH)
+        this.linkFee = linkFee; // (uint192) Base cost to validate a transaction using the report, denominated in LINK
+        this.expiresAt = expiresAt; // (uint32) Latest timestamp where the report can be verified on-chain
+        this.benchmarkPrice = benchmarkPrice; // (int192) DON consensus median price, carried to 8 decimal places
+    }
+}
+
+class ReportV3 {
+    constructor({
+        feedId,
+        validFromTimestamp,
+        observationsTimestamp,
+        nativeFee,
+        linkFee,
+        expiresAt,
+        price,
+        bid,
+        ask,
+    }) {
+        this.feedId = feedId; // (bytes32) The stream ID the report has data for
+        this.validFromTimestamp = validFromTimestamp; // (uint32) Earliest timestamp for which price is applicable
+        this.observationsTimestamp = observationsTimestamp; // (uint32) Latest timestamp for which price is applicable
+        this.nativeFee = nativeFee; // (uint192) Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH)
+        this.linkFee = linkFee; // (uint192) Base cost to validate a transaction using the report, denominated in LINK
+        this.expiresAt = expiresAt; // (uint32) Latest timestamp where the report can be verified on-chain
+        this.price = price; // (int192) DON consensus median price (8 or 18 decimals)
+        this.bid = bid; // (int192) Simulated price impact of a buy order up to the X% depth of liquidity utilisation (8 or 18 decimals)
+        this.ask = ask; // (int192) Simulated price impact of a sell order up to the X% depth of liquidity utilisation (8 or 18 decimals)
+    }
+}
+
+class ReportV4 {
+    constructor({
+        feedId,
+        validFromTimestamp,
+        observationsTimestamp,
+        nativeFee,
+        linkFee,
+        expiresAt,
+        price,
+        marketStatus,
+    }) {
+        this.feedId = feedId; // (bytes32) The stream ID the report has data for
+        this.validFromTimestamp = validFromTimestamp; // (uint32) Earliest timestamp for which price is applicable
+        this.observationsTimestamp = observationsTimestamp; // (uint32) Latest timestamp for which price is applicable
+        this.nativeFee = nativeFee; // (uint192) Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH)
+        this.linkFee = linkFee; // (uint192) Base cost to validate a transaction using the report, denominated in LINK
+        this.expiresAt = expiresAt; // (uint32) Latest timestamp where the report can be verified on-chain
+        this.price = price; // (int192) DON consensus median benchmark price (8 or 18 decimals)
+        this.marketStatus = marketStatus; // (uint32) The DON's consensus on whether the market is currently open
+    }
+}
+
+module.exports = {
+    ReportV2,
+    ReportV3,
+    ReportV4
+}

--- a/scripts/examples/DataStreamsConsumerFork.ts
+++ b/scripts/examples/DataStreamsConsumerFork.ts
@@ -1,0 +1,97 @@
+import { ethers, network } from "hardhat";
+import { requestLinkFromFaucet, requestNativeFromFaucet } from "../data-streams/DataStreamsLocalSimulatorFork";
+
+// 1st Terminal: npx hardhat node
+// 2nd Terminal: npx hardhat run ./scripts/examples/DataStreamsConsumerFork.ts --network localhost
+
+async function main() {
+    const verifierProxyInterface = new ethers.Interface([
+        "function verify(bytes calldata payload, bytes calldata parameterPayload) external payable returns (bytes memory verifierResponse)",
+        "function s_feeManager() external view returns (address)"
+    ]);
+
+    const feeManagerInterface = new ethers.Interface([
+        "function getFeeAndReward(address subscriber, bytes memory unverifiedReport, address quoteAddress) external returns ((address token,uint256 amount) memory, (address token,uint256 amount) memory, uint256)",
+        "function i_linkAddress() external view returns (address)",
+        "function i_nativeAddress() external view returns (address)",
+        "function i_rewardManager() external view returns (address)"
+    ]);
+
+    const erc20Interface = new ethers.Interface(["function approve(address spender, uint256 amount) external returns (bool)"]);
+
+    const ARBITRUM_SEPOLIA_RPC_URL = process.env.ARBITRUM_SEPOLIA_RPC_URL;
+
+    await network.provider.request({
+        method: "hardhat_reset",
+        params: [{
+            forking: {
+                jsonRpcUrl: ARBITRUM_SEPOLIA_RPC_URL,
+                blockNumber: 99556570
+            },
+        }],
+    });
+
+    const [alice] = await ethers.getSigners();
+
+    const UNVERIFIED_INPUT_REPORT = "0x0006f9b553e393ced311551efd30d1decedb63d76ad41737462e2cdbbdff1578000000000000000000000000000000000000000000000000000000004b0b4006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000028001010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000120000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba7820000000000000000000000000000000000000000000000000000000067407f400000000000000000000000000000000000000000000000000000000067407f4000000000000000000000000000000000000000000000000000001b1fa2a2d6400000000000000000000000000000000000000000000000000016e76dd08b2c34000000000000000000000000000000000000000000000000000000006741d0c00000000000000000000000000000000000000000000000b5c654dd994866cb600000000000000000000000000000000000000000000000b5c6042e4f23a92c400000000000000000000000000000000000000000000000b5c7dc7c8e30df80000000000000000000000000000000000000000000000000000000000000000002f68eeb7e489bef244eb83d56e1b8af210a65363e5ad4407f374e5c06f46db98c36b4181b70329535011ba504fb8e09570c10a6de7f1f138cf322237c72cb0d650000000000000000000000000000000000000000000000000000000000000002648579956ffb863e4ea9470a87bb59b26e91ea893f96c2ab933786e531f2701a06d92b4e896a42d40d19a3b5ba1711d5f00bc262084d7afce44a5bbde3014fe5";
+
+    const EXPECTED_REPORT_DATA = {
+        feedId: "0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782",
+        validFromTimestamp: 1732280128,
+        observationsTimestamp: 1732280128,
+        nativeFee: 29822686516800,
+        linkFee: 6446908323867700,
+        expiresAt: 1732366528,
+        price: 3353151968509396700000n,
+        bid: 3353129257778281000000n,
+        ask: 3353262200000000000000n
+    };
+
+    const verifierProxyAddress = `0x2ff010DEbC1297f19579B4246cad07bd24F2488A`;
+    const verifierProxy = new ethers.Contract(verifierProxyAddress, verifierProxyInterface, alice);
+
+    const feeManagerAddress = await verifierProxy.s_feeManager();
+    const feeManager = new ethers.Contract(feeManagerAddress, feeManagerInterface, alice);
+
+    const rewardManagerAddress = await feeManager.i_rewardManager();
+
+    const defaultAbiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+    const [, reportData] = defaultAbiCoder.decode(["bytes32[3]", "bytes"], UNVERIFIED_INPUT_REPORT);
+
+    console.log(reportData);
+
+    // Pay for verification in LINK
+    let feeTokenAddress = await feeManager.i_linkAddress();
+
+    await requestLinkFromFaucet(feeTokenAddress, alice.address, EXPECTED_REPORT_DATA.linkFee);
+
+    const linkToken = new ethers.Contract(feeTokenAddress, erc20Interface, alice);
+    await linkToken.approve(rewardManagerAddress, EXPECTED_REPORT_DATA.linkFee);
+
+    let parameterPayload = defaultAbiCoder.encode(["address"], [feeTokenAddress]);
+
+    await verifierProxy.verify(UNVERIFIED_INPUT_REPORT, parameterPayload); // this must not revert
+
+    // Pay for verification in Native
+    feeTokenAddress = await feeManager.i_nativeAddress();
+    const gasCosts = ethers.parseEther("0.1");
+    await requestNativeFromFaucet(alice.address, EXPECTED_REPORT_DATA.nativeFee + Number(gasCosts));
+
+    parameterPayload = defaultAbiCoder.encode(["address"], [feeTokenAddress]);
+
+    await verifierProxy.verify(UNVERIFIED_INPUT_REPORT, parameterPayload, { value: EXPECTED_REPORT_DATA.nativeFee }); // this must not revert
+
+    // const txData = verifierProxy.interface.encodeFunctionData("verify", [UNVERIFIED_INPUT_REPORT, parameterPayload]);
+    // const txResult = await alice.call({
+    //     to: verifierProxyAddress,
+    //     data: txData,
+    // });
+    // console.log(txResult);
+}
+
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/data-streams/DataStreamsLocalSimulator.sol
+++ b/src/data-streams/DataStreamsLocalSimulator.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {WETH9} from "../shared/WETH9.sol";
+import {LinkToken} from "../shared/LinkToken.sol";
+import {MockVerifier} from "./MockVerifier.sol";
+import {MockVerifierProxy} from "./MockVerifierProxy.sol";
+import {MockFeeManager} from "./MockFeeManager.sol";
+import {MockRewardManager} from "./MockRewardManager.sol";
+
+contract DataStreamsLocalSimulator {
+    MockVerifier internal s_mockVerifier;
+    MockVerifierProxy internal s_mockVerifierProxy;
+    MockFeeManager internal s_mockFeeManager;
+    MockRewardManager internal s_mockRewardManager;
+
+    /// @notice The wrapped native token instance
+    WETH9 internal immutable i_wrappedNative;
+
+    /// @notice The LINK token instance
+    LinkToken internal immutable i_linkToken;
+
+    constructor() {
+        i_wrappedNative = new WETH9();
+        i_linkToken = new LinkToken();
+
+        s_mockVerifierProxy = new MockVerifierProxy();
+        s_mockVerifier = new MockVerifier(address(s_mockVerifierProxy));
+        s_mockVerifierProxy.initializeVerifier(address(s_mockVerifier));
+
+        s_mockRewardManager = new MockRewardManager(address(i_linkToken));
+
+        s_mockFeeManager = new MockFeeManager(
+            address(i_linkToken), address(i_wrappedNative), address(s_mockVerifierProxy), address(s_mockRewardManager)
+        );
+
+        s_mockVerifierProxy.setFeeManager(s_mockFeeManager);
+        s_mockRewardManager.setFeeManager(address(s_mockFeeManager));
+    }
+
+    /**
+     * @notice Requests LINK tokens from the faucet. The provided amount of tokens are transferred to provided destination address.
+     *
+     * @param to - The address to which LINK tokens are to be sent.
+     * @param amount - The amount of LINK tokens to send.
+     *
+     * @return success - Returns `true` if the transfer of tokens was successful, otherwise `false`.
+     */
+    function requestLinkFromFaucet(address to, uint256 amount) external returns (bool success) {
+        success = i_linkToken.transfer(to, amount);
+    }
+
+    /**
+     *  @notice Returns configuration details for pre-deployed contracts and services needed for local Data Streams simulations.
+     *
+     * @return wrappedNative_ - The wrapped native token.
+     * @return linkToken_ - The LINK token.
+     * @return mockVerifier_ - The mock verifier contract.
+     * @return mockVerifierProxy_ - The mock verifier proxy contract.
+     * @return mockFeeManager_ - The mock fee manager contract.
+     * @return mockRewardManager_ - The mock reward manager contract.
+     */
+    function configuration()
+        public
+        view
+        returns (
+            WETH9 wrappedNative_,
+            LinkToken linkToken_,
+            MockVerifier mockVerifier_,
+            MockVerifierProxy mockVerifierProxy_,
+            MockFeeManager mockFeeManager_,
+            MockRewardManager mockRewardManager_
+        )
+    {
+        return
+            (i_wrappedNative, i_linkToken, s_mockVerifier, s_mockVerifierProxy, s_mockFeeManager, s_mockRewardManager);
+    }
+}

--- a/src/data-streams/DataStreamsLocalSimulatorFork.sol
+++ b/src/data-streams/DataStreamsLocalSimulatorFork.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {Register} from "./Register.sol";
+import {IERC20} from "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.0/contracts/interfaces/IERC20.sol";
+
+contract DataStreamsLocalSimulatorFork is Test {
+    /// @notice The immutable register instance
+    Register immutable i_register;
+
+    /// @notice The address of the LINK faucet
+    address constant LINK_FAUCET = 0x4281eCF07378Ee595C564a59048801330f3084eE;
+
+    /**
+     * @notice Constructor to initialize the contract
+     */
+    constructor() {
+        i_register = new Register();
+    }
+
+    /**
+     * @notice Returns the default values for currently Data Streams supported networks. If network is not present or some of the values are changed, user can manually add new network details using the `setNetworkDetails` function.
+     *
+     * @param chainId - The blockchain network chain ID. For example 11155111 for Ethereum Sepolia.
+     *
+     * @return networkDetails - The tuple containing:
+     *          verifierProxyAddress - The address of the Verifier Proxy smart contract.
+     *          linkAddress - The address of the LINK token.
+     */
+    function getNetworkDetails(uint256 chainId) external view returns (Register.NetworkDetails memory) {
+        return i_register.getNetworkDetails(chainId);
+    }
+
+    /**
+     * @notice If network details are not present or some of the values are changed, user can manually add new network details using the `setNetworkDetails` function.
+     *
+     * @param chainId - The blockchain network chain ID. For example 11155111 for Ethereum Sepolia.
+     * @param networkDetails - The tuple containing:
+     *          verifierProxyAddress - The address of the Verifier Proxy smart contract.
+     *          linkAddress - The address of the LINK token.
+     */
+    function setNetworkDetails(uint256 chainId, Register.NetworkDetails memory networkDetails) external {
+        i_register.setNetworkDetails(chainId, networkDetails);
+    }
+
+    /**
+     * @notice Requests LINK tokens from the faucet. The provided amount of tokens are transferred to provided destination address.
+     *
+     * @param to - The address to which LINK tokens are to be sent.
+     * @param amount - The amount of LINK tokens to send.
+     *
+     * @return success - Returns `true` if the transfer of tokens was successful, otherwise `false`.
+     */
+    function requestLinkFromFaucet(address to, uint256 amount) external returns (bool success) {
+        address linkAddress = i_register.getNetworkDetails(block.chainid).linkAddress;
+
+        vm.startPrank(LINK_FAUCET);
+        success = IERC20(linkAddress).transfer(to, amount);
+        vm.stopPrank();
+    }
+
+    /**
+     * @notice Requests native coints from the faucet.
+     *
+     * @param to - The address to which native coins are to be sent.
+     * @param amount - The amount of native coins to send.
+     */
+    function requestNativeFromFaucet(address to, uint256 amount) external {
+        vm.deal(to, amount);
+    }
+}

--- a/src/data-streams/MockFeeManager.sol
+++ b/src/data-streams/MockFeeManager.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {OwnerIsCreator} from "@chainlink/contracts/src/v0.8/shared/access/OwnerIsCreator.sol";
+import {IERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IWERC20} from "@chainlink/contracts/src/v0.8/shared/interfaces/IWERC20.sol";
+import {Math} from "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/utils/math/Math.sol";
+
+// import {IRewardManager} from "@chainlink/contracts/src/v0.8/llo-feeds/interfaces/IRewardManager.sol";
+// import {IVerifierFeeManager} from "@chainlink/contracts/src/v0.8/llo-feeds/interfaces/IVerifierFeeManager.sol";
+import {IRewardManager} from "./interfaces/IRewardManager.sol";
+import {IVerifierFeeManager} from "./interfaces/IVerifierFeeManager.sol";
+
+library Common {
+    // @notice The asset struct to hold the address of an asset and amount
+    struct Asset {
+        address assetAddress;
+        uint256 amount;
+    }
+}
+
+contract MockFeeManager is IVerifierFeeManager, OwnerIsCreator {
+    using SafeERC20 for IERC20;
+
+    error Unauthorized();
+    error InvalidAddress();
+    error InvalidQuote();
+    error ExpiredReport();
+    error InvalidDiscount();
+    error InvalidSurcharge();
+    error InvalidDeposit();
+
+    /// @notice the total discount that can be applied to a fee, 1e18 = 100% discount
+    uint64 private constant PERCENTAGE_SCALAR = 1e18;
+
+    address public immutable i_linkAddress;
+    address public immutable i_nativeAddress;
+    address public immutable i_proxyAddress;
+    IRewardManager public immutable i_rewardManager;
+
+    uint256 public s_nativeSurcharge;
+    mapping(address => uint256) public s_mockDiscounts;
+
+    modifier onlyProxy() {
+        if (msg.sender != i_proxyAddress) revert Unauthorized();
+        _;
+    }
+
+    constructor(address linkAddress, address nativeAddress, address proxyAddress, address rewardManager) {
+        i_linkAddress = linkAddress;
+        i_nativeAddress = nativeAddress;
+        i_proxyAddress = proxyAddress;
+        i_rewardManager = IRewardManager(rewardManager);
+
+        IERC20(i_linkAddress).approve(address(i_rewardManager), type(uint256).max);
+    }
+
+    function processFee(bytes calldata payload, bytes calldata parameterPayload, address subscriber)
+        external
+        payable
+        override
+        onlyProxy
+    {
+        _processFee(payload, parameterPayload, subscriber);
+    }
+
+    function processFeeBulk(bytes[] calldata payloads, bytes calldata parameterPayload, address subscriber)
+        external
+        payable
+        override
+        onlyProxy
+    {
+        for (uint256 i = 0; i < payloads.length; i++) {
+            _processFee(payloads[i], parameterPayload, subscriber);
+        }
+    }
+
+    function getFeeAndReward(address subscriber, bytes memory report, address quoteAddress)
+        public
+        view
+        returns (Common.Asset memory, Common.Asset memory, uint256)
+    {
+        Common.Asset memory fee;
+        Common.Asset memory reward;
+
+        //verify the quote payload is a supported token
+        if (quoteAddress != i_nativeAddress && quoteAddress != i_linkAddress) {
+            revert InvalidQuote();
+        }
+
+        //decode the report depending on the version
+        uint256 linkQuantity;
+        uint256 nativeQuantity;
+        uint256 expiresAt;
+        (,,, nativeQuantity, linkQuantity, expiresAt) =
+            abi.decode(report, (bytes32, uint32, uint32, uint192, uint192, uint32));
+
+        //read the timestamp bytes from the report data and verify it has not expired
+        if (expiresAt < block.timestamp) {
+            revert ExpiredReport();
+        }
+
+        uint256 discount = s_mockDiscounts[subscriber];
+
+        //the reward is always set in LINK
+        reward.assetAddress = i_linkAddress;
+        reward.amount = Math.ceilDiv(linkQuantity * (PERCENTAGE_SCALAR - discount), PERCENTAGE_SCALAR);
+
+        //calculate either the LINK fee or native fee if it's within the report
+        if (quoteAddress == i_linkAddress) {
+            fee.assetAddress = i_linkAddress;
+            fee.amount = reward.amount;
+        } else {
+            uint256 surchargedFee =
+                Math.ceilDiv(nativeQuantity * (PERCENTAGE_SCALAR + s_nativeSurcharge), PERCENTAGE_SCALAR);
+
+            fee.assetAddress = i_nativeAddress;
+            fee.amount = Math.ceilDiv(surchargedFee * (PERCENTAGE_SCALAR - discount), PERCENTAGE_SCALAR);
+        }
+
+        return (fee, reward, discount);
+    }
+
+    function _processFee(bytes calldata payload, bytes calldata parameterPayload, address subscriber) internal {
+        if (subscriber == address(this)) revert InvalidAddress();
+        address quote = abi.decode(parameterPayload, (address));
+
+        (, bytes memory report) = abi.decode(payload, (bytes32[3], bytes));
+
+        (Common.Asset memory fee, /*Common.Asset memory reward*/, /*uint256 appliedDiscount*/ ) =
+            getFeeAndReward(subscriber, report, quote);
+
+        if (fee.assetAddress == i_linkAddress) {
+            IRewardManager.FeePayment[] memory payments = new IRewardManager.FeePayment[](1);
+            payments[0] = IRewardManager.FeePayment({poolId: bytes32(0), amount: uint192(fee.amount)});
+            i_rewardManager.onFeePaid(payments, subscriber);
+        } else {
+            if (msg.value != 0) {
+                if (fee.amount > msg.value) revert InvalidDeposit();
+
+                IWERC20(i_nativeAddress).deposit{value: fee.amount}();
+
+                uint256 change;
+                unchecked {
+                    change = msg.value - fee.amount;
+                }
+
+                if (change > 0) {
+                    payable(subscriber).transfer(change);
+                }
+            } else {
+                IERC20(i_nativeAddress).safeTransferFrom(subscriber, address(this), fee.amount);
+            }
+        }
+    }
+
+    function setNativeSurcharge(uint64 surcharge) external {
+        if (surcharge > PERCENTAGE_SCALAR) revert InvalidSurcharge();
+
+        s_nativeSurcharge = surcharge;
+    }
+
+    function setMockDiscount(address subscriber, uint256 discount) external {
+        if (discount > PERCENTAGE_SCALAR) revert InvalidDiscount();
+
+        s_mockDiscounts[subscriber] = discount;
+    }
+
+    function getMockDiscount(address subscriber) external view returns (uint256) {
+        return s_mockDiscounts[subscriber];
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == this.processFee.selector || interfaceId == this.processFeeBulk.selector;
+    }
+}

--- a/src/data-streams/MockReportGenerator.sol
+++ b/src/data-streams/MockReportGenerator.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {ReportVersions} from "./ReportVersions.sol";
+
+contract MockReportGenerator is Test, ReportVersions {
+    address internal immutable i_donAddress;
+    uint256 internal immutable i_donDigest;
+
+    bytes32 internal immutable i_reportV2MockFeedId =
+        hex"0002777777777777777777777777777777777777777777777777777777777777";
+    bytes32 internal immutable i_reportV3MockFeedId =
+        hex"0003777777777777777777777777777777777777777777777777777777777777";
+    bytes32 internal immutable i_reportV4MockFeedId =
+        hex"0004777777777777777777777777777777777777777777777777777777777777";
+
+    int192 internal s_price;
+    int192 internal s_bid;
+    int192 internal s_ask;
+    uint32 internal s_expiresPeriod;
+    uint32 internal s_marketStatus;
+    uint192 internal s_nativeFee; // 0 by default
+    uint192 internal s_linkFee; // 0 by default
+
+    error MockReportGenerator__InvalidBid();
+    error MockReportGenerator__InvalidAsk();
+    error MockReportGenerator__CastOverflow();
+
+    constructor(int192 initialPrice) {
+        updatePrice(initialPrice);
+        s_expiresPeriod = 1 days;
+        s_marketStatus = 2; // 0 (Unknown), 1 (Closed), 2 (Open)
+        (i_donAddress, i_donDigest) = makeAddrAndKey("Mock Data Streams DON");
+    }
+
+    function generateReport(ReportV2 calldata report) external returns (bytes memory signedReport) {
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function generateReport(ReportV3 calldata report) external returns (bytes memory signedReport) {
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function generateReport(ReportV4 calldata report) external returns (bytes memory signedReport) {
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function generateReportV2() external returns (bytes memory signedReport, ReportV2 memory report) {
+        report = ReportV2({
+            feedId: i_reportV2MockFeedId,
+            validFromTimestamp: toUint32(block.timestamp),
+            observationsTimestamp: toUint32(block.timestamp),
+            nativeFee: s_nativeFee,
+            linkFee: s_linkFee,
+            expiresAt: toUint32(block.timestamp + s_expiresPeriod),
+            benchmarkPrice: s_price
+        });
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function generateReportV3() external returns (bytes memory signedReport, ReportV3 memory report) {
+        report = ReportV3({
+            feedId: i_reportV3MockFeedId,
+            validFromTimestamp: toUint32(block.timestamp),
+            observationsTimestamp: toUint32(block.timestamp),
+            nativeFee: s_nativeFee,
+            linkFee: s_linkFee,
+            expiresAt: toUint32(block.timestamp + s_expiresPeriod),
+            price: s_price,
+            bid: s_bid,
+            ask: s_ask
+        });
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function generateReportV4() external returns (bytes memory signedReport, ReportV4 memory report) {
+        report = ReportV4({
+            feedId: i_reportV4MockFeedId,
+            validFromTimestamp: toUint32(block.timestamp),
+            observationsTimestamp: toUint32(block.timestamp),
+            nativeFee: s_nativeFee,
+            linkFee: s_linkFee,
+            expiresAt: toUint32(block.timestamp + s_expiresPeriod),
+            price: s_price,
+            marketStatus: s_marketStatus
+        });
+        bytes memory reportData = abi.encode(report);
+        signedReport = signReport(reportData);
+    }
+
+    function updatePrice(int192 price) public {
+        s_price = price;
+        int192 delta = price / 1000; // 0.1% = 1/1000
+        s_bid = price - delta;
+        s_ask = price + delta;
+    }
+
+    function updatePriceBidAndAsk(int192 price, int192 bid, int192 ask) external {
+        // bid < price < ask
+        if (bid >= price) revert MockReportGenerator__InvalidBid();
+        if (ask <= price) revert MockReportGenerator__InvalidAsk();
+
+        s_price = price;
+        s_bid = bid;
+        s_ask = ask;
+    }
+
+    function updateExpiresPeriod(uint32 period) external {
+        s_expiresPeriod = period;
+    }
+
+    function updateMarketStatus(uint32 status) external {
+        s_marketStatus = status;
+    }
+
+    function updateFees(uint192 nativeFee, uint192 linkFee) external {
+        s_nativeFee = nativeFee;
+        s_linkFee = linkFee;
+    }
+
+    function getMockDonAddress() external view returns (address) {
+        return i_donAddress;
+    }
+
+    function signReport(bytes memory reportData) private returns (bytes memory signedReport) {
+        bytes32[3] memory reportContext;
+        bytes32[] memory rawRs = new bytes32[](1);
+        bytes32[] memory rawSs = new bytes32[](1);
+        bytes32 rawVs;
+
+        reportContext[0] = bytes32(i_donDigest);
+        reportContext[1] = ""; // not needed for mocks
+        reportContext[2] = ""; // not needed for mocks
+
+        vm.startPrank(i_donAddress);
+        bytes32 hashedReport = keccak256(reportData);
+        bytes32 h = keccak256(abi.encodePacked(hashedReport, reportContext));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(i_donDigest, h);
+        vm.stopPrank();
+
+        rawRs[0] = r;
+        rawSs[0] = s;
+        rawVs = bytes32(uint256(v));
+
+        return abi.encode(reportContext, reportData, rawRs, rawSs, rawVs);
+    }
+
+    function toUint32(uint256 timestamp) private pure returns (uint32) {
+        if (timestamp > type(uint32).max) {
+            revert MockReportGenerator__CastOverflow();
+        }
+        return uint32(timestamp);
+    }
+}

--- a/src/data-streams/MockRewardManager.sol
+++ b/src/data-streams/MockRewardManager.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {OwnerIsCreator} from "@chainlink/contracts/src/v0.8/shared/access/OwnerIsCreator.sol";
+import {IERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
+
+// import {IRewardManager} from "@chainlink/contracts/src/v0.8/llo-feeds/interfaces/IRewardManager.sol";
+import {IRewardManager} from "./interfaces/IRewardManager.sol";
+
+contract MockRewardManager is IRewardManager {
+    using SafeERC20 for IERC20;
+
+    error Unauthorized();
+
+    address public immutable i_linkAddress;
+    address public s_feeManagerAddress;
+
+    event FeePaid(IRewardManager.FeePayment[] payments, address payer);
+
+    modifier onlyFeeManager() {
+        if (msg.sender != s_feeManagerAddress) revert Unauthorized();
+        _;
+    }
+
+    constructor(address linkAddress) {
+        i_linkAddress = linkAddress;
+    }
+
+    function onFeePaid(FeePayment[] calldata payments, address payer) external override onlyFeeManager {
+        uint256 totalFeeAmount;
+        for (uint256 i; i < payments.length; ++i) {
+            unchecked {
+                // Tally the total payable fees
+                totalFeeAmount += payments[i].amount;
+            }
+        }
+
+        // Transfer fees to this contract
+        IERC20(i_linkAddress).safeTransferFrom(payer, address(this), totalFeeAmount);
+
+        emit FeePaid(payments, payer);
+    }
+
+    function claimRewards(bytes32[] memory /*poolIds*/ ) external pure override {
+        revert("Not implemented");
+    }
+
+    function setFeeManager(address newFeeManager) external override {
+        s_feeManagerAddress = newFeeManager;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == this.onFeePaid.selector;
+    }
+}

--- a/src/data-streams/MockVerifier.sol
+++ b/src/data-streams/MockVerifier.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IERC165} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/interfaces/IERC165.sol";
+
+contract MockVerifier is IERC165 {
+    error AccessForbidden();
+    error InactiveFeed(bytes32 feedId);
+    error DigestInactive(bytes32 feedId, bytes32 configDigest);
+    error BadVerification();
+    error InvalidV();
+    error AlreadyUsedSignature();
+    error InvalidSignatureLength();
+    error InvalidS();
+
+    // secp256k1 Curve Order N / 2 (to prevent signature malleability s <= N / 2)
+    uint256 constant N_2 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
+    // Generated from uint256(keccak256(abi.encodePacked("Mock Data Streams DON")));
+    address constant MOCK_DATA_STREAM_DON_ADDRESS = 0x143f40b47ab222503b787e98940023c59fc29984;
+
+    address internal immutable i_verifierProxy;
+
+    mapping(bytes32 => mapping(bytes32 => bool)) internal s_inactiveDigests;
+    mapping(bytes32 => bool) internal s_inactiveFeeds;
+    mapping(bytes => bool) internal s_verifiedSignatures;
+
+    event ReportVerified(bytes32 indexed feedId, address indexed sender);
+
+    constructor(address verifierProxy) {
+        i_verifierProxy = verifierProxy;
+    }
+
+    function verify(bytes calldata signedReport, address sender) external returns (bytes memory verifierResponse) {
+        if (msg.sender != i_verifierProxy) revert AccessForbidden();
+
+        (
+            bytes32[3] memory reportContext,
+            bytes memory reportData,
+            bytes32[] memory rs,
+            bytes32[] memory ss,
+            bytes32 rawVs
+        ) = abi.decode(signedReport, (bytes32[3], bytes, bytes32[], bytes32[], bytes32));
+
+        // The feed ID is the first 32 bytes of the report data.
+        bytes32 feedId = bytes32(reportData);
+        if (s_inactiveFeeds[feedId]) revert InactiveFeed(feedId);
+
+        bytes32 configDigest = reportContext[0];
+        if (s_inactiveDigests[feedId][configDigest]) revert DigestInactive(feedId, configDigest);
+
+        // Decoding recid (v) like this works only for the mock verifier. In fork mode, use Verifier.sol from @chainlink/contracts.
+        uint8 v = uint8(uint256(rawVs));
+        // Recid (v) can also be 0 or 1, however 0x01 precompile expects 27 or 28.
+        if (v < 27) v += 27;
+        // Prevents signature malleability
+        if (v != 27 && v != 28) revert InvalidV();
+
+        bytes memory signature = abi.encodePacked(rs[0], ss[0], v);
+
+        // Prevents replay attacks
+        if (s_verifiedSignatures[signature]) revert AlreadyUsedSignature();
+
+        // MockReportGenerator will only generate standard "r,s,v" signatures. EIP-2098 and ERC-1271 are not supported.
+        if (signature.length != 65) revert InvalidSignatureLength();
+
+        // Prevents signature malleability using EIP-2
+        if (uint256(ss[0]) > N_2) revert InvalidS();
+
+        // Expired signatures are handled in MockVerifierProxy.sol
+        // In local mode we don't care about cross-chain replay attacks, because everything is on one local network.
+
+        bytes32 hashedReport = keccak256(reportData);
+        bytes32 h = keccak256(abi.encodePacked(hashedReport, reportContext));
+
+        address signer = ecrecover(h, v, rs[0], ss[0]);
+        if (signer != MOCK_DATA_STREAM_DON_ADDRESS) revert BadVerification();
+
+        s_verifiedSignatures[signature] = true;
+        emit ReportVerified(feedId, sender);
+
+        return reportData;
+    }
+
+    function deactivateConfig(bytes32 feedId, bytes32 configDigest) external {
+        s_inactiveDigests[feedId][configDigest] = true;
+    }
+
+    function activateConfig(bytes32 feedId, bytes32 configDigest) external {
+        s_inactiveDigests[feedId][configDigest] = false;
+    }
+
+    function deactivateFeed(bytes32 feedId) external {
+        s_inactiveFeeds[feedId] = true;
+    }
+
+    function activateFeed(bytes32 feedId) external {
+        s_inactiveFeeds[feedId] = false;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == this.verify.selector;
+    }
+}

--- a/src/data-streams/MockVerifierProxy.sol
+++ b/src/data-streams/MockVerifierProxy.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {OwnerIsCreator} from "@chainlink/contracts/src/v0.8/shared/access/OwnerIsCreator.sol";
+import {IERC165} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/interfaces/IERC165.sol";
+
+// import {IVerifier} from "@chainlink/contracts/src/v0.8/llo-feeds/interfaces/IVerifier.sol";
+// import {IVerifierFeeManager} from "@chainlink/contracts/src/v0.8/llo-feeds/interfaces/IVerifierFeeManager.sol";
+import {IVerifier} from "./interfaces/IVerifier.sol";
+import {IVerifierFeeManager} from "./interfaces/IVerifierFeeManager.sol";
+
+contract MockVerifierProxy is OwnerIsCreator {
+    error ZeroAddress();
+    error VerifierInvalid();
+    error VerifierNotFound();
+
+    address internal s_verifier;
+    IVerifierFeeManager public s_feeManager;
+
+    event VerifierInitialized(address indexed verifierAddress);
+
+    modifier onlyValidVerifier(address verifierAddress) {
+        if (verifierAddress == address(0)) revert ZeroAddress();
+        if (!IERC165(verifierAddress).supportsInterface(IVerifier.verify.selector)) revert VerifierInvalid();
+        _;
+    }
+
+    function verify(bytes calldata payload, bytes calldata parameterPayload) external payable returns (bytes memory) {
+        IVerifierFeeManager feeManager = s_feeManager;
+
+        // Bill the verifier
+        if (address(feeManager) != address(0)) {
+            feeManager.processFee{value: msg.value}(payload, parameterPayload, msg.sender);
+        }
+
+        return _verify(payload);
+    }
+
+    function verifyBulk(bytes[] calldata payloads, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes[] memory verifiedReports)
+    {
+        IVerifierFeeManager feeManager = s_feeManager;
+
+        // Bill the verifier
+        if (address(feeManager) != address(0)) {
+            feeManager.processFeeBulk{value: msg.value}(payloads, parameterPayload, msg.sender);
+        }
+
+        // Verify reports
+        verifiedReports = new bytes[](payloads.length);
+        for (uint256 i; i < payloads.length; ++i) {
+            verifiedReports[i] = _verify(payloads[i]);
+        }
+
+        return verifiedReports;
+    }
+
+    function _verify(bytes calldata payload) internal returns (bytes memory) {
+        if (s_verifier == address(0)) revert VerifierNotFound();
+
+        return IVerifier(s_verifier).verify(payload, msg.sender);
+    }
+
+    function initializeVerifier(address verifierAddress) external onlyOwner onlyValidVerifier(verifierAddress) {
+        s_verifier = verifierAddress;
+        emit VerifierInitialized(verifierAddress);
+    }
+
+    function getVerifier(bytes32 /*configDigest*/ ) external view returns (address) {
+        return s_verifier;
+    }
+
+    function setFeeManager(IVerifierFeeManager feeManager) external {
+        s_feeManager = feeManager;
+    }
+}

--- a/src/data-streams/Register.sol
+++ b/src/data-streams/Register.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Register Contract
+/// @notice This contract allows storing and retrieving network details for various chains.
+/// @dev Stores network details in a mapping based on chain IDs.
+contract Register {
+    struct NetworkDetails {
+        address verifierProxyAddress;
+        address linkAddress;
+    }
+
+    /// @notice Mapping to store network details based on chain ID.
+    mapping(uint256 chainId => NetworkDetails) internal s_networkDetails;
+
+    /// @notice Constructor to initialize the network details for various chains.
+    constructor() {
+        // Arbitrum Sepolia
+        s_networkDetails[421614] = NetworkDetails({
+            verifierProxyAddress: 0x2ff010DEbC1297f19579B4246cad07bd24F2488A,
+            linkAddress: 0xb1D4538B4571d411F07960EF2838Ce337FE1E80E
+        });
+
+        // Avalanche Fuji
+        s_networkDetails[43113] = NetworkDetails({
+            verifierProxyAddress: 0x2bf612C65f5a4d388E687948bb2CF842FFb8aBB3,
+            linkAddress: 0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846
+        });
+
+        // Base Sepolia
+        s_networkDetails[84532] = NetworkDetails({
+            verifierProxyAddress: 0x8Ac491b7c118a0cdcF048e0f707247fD8C9575f9,
+            linkAddress: 0xE4aB69C077896252FAFBD49EFD26B5D171A32410
+        });
+
+        // opBNB Testnet
+        s_networkDetails[5611] =
+            NetworkDetails({verifierProxyAddress: 0x001225Aca0efe49Dbb48233aB83a9b4d177b581A, linkAddress: address(0)});
+
+        // Soneium Minato Testnet
+        s_networkDetails[1946] = NetworkDetails({
+            verifierProxyAddress: 0x26603bAC5CE09DAE5604700B384658AcA13AD6ae,
+            linkAddress: 0x7ea13478Ea3961A0e8b538cb05a9DF0477c79Cd2
+        });
+    }
+
+    /**
+     * @notice Retrieves network details for a given chain ID.
+     *
+     * @param chainId - The ID of the chain to get the details for.
+     * @return networkDetails - The network details for the specified chain ID.
+     */
+    function getNetworkDetails(uint256 chainId) external view returns (NetworkDetails memory networkDetails) {
+        networkDetails = s_networkDetails[chainId];
+    }
+
+    /**
+     * @notice Sets the network details for a given chain ID.
+     *
+     * @param chainId - The ID of the chain to set the details for.
+     * @param networkDetails - The network details to set for the specified chain ID.
+     */
+    function setNetworkDetails(uint256 chainId, NetworkDetails memory networkDetails) external {
+        s_networkDetails[chainId] = networkDetails;
+    }
+}

--- a/src/data-streams/ReportVersions.sol
+++ b/src/data-streams/ReportVersions.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract ReportVersions {
+    /**
+     * @dev Represents a data report from a Data Streams stream for v2 schema (crypto streams).
+     * The `price` value is carried to either 8 or 18 decimal places, depending on the stream.
+     * For more information, see https://docs.chain.link/data-streams/crypto-streams and https://docs.chain.link/data-streams/reference/report-schema
+     */
+    struct ReportV2 {
+        bytes32 feedId; // The feed ID the report has data for
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (WETH/ETH)
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK
+        uint32 expiresAt; // Latest timestamp where the report can be verified on-chain
+        int192 benchmarkPrice; // DON consensus median price, carried to 8 decimal places
+    }
+
+    /**
+     * @dev Represents a data report from a Data Streams stream for v3 schema (crypto streams).
+     * The `price`, `bid`, and `ask` values are carried to either 8 or 18 decimal places, depending on the stream.
+     * For more information, see https://docs.chain.link/data-streams/crypto-streams and https://docs.chain.link/data-streams/reference/report-schema
+     */
+    struct ReportV3 {
+        bytes32 feedId; // The stream ID the report has data for.
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable.
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable.
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH).
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK.
+        uint32 expiresAt; // Latest timestamp where the report can be verified onchain.
+        int192 price; // DON consensus median price (8 or 18 decimals).
+        int192 bid; // Simulated price impact of a buy order up to the X% depth of liquidity utilisation (8 or 18 decimals).
+        int192 ask; // Simulated price impact of a sell order up to the X% depth of liquidity utilisation (8 or 18 decimals).
+    }
+
+    /**
+     * @dev Represents a data report from a Data Streams stream for v4 schema (RWA stream).
+     * The `price` value is carried to either 8 or 18 decimal places, depending on the stream.
+     * The `marketStatus` indicates whether the market is currently open. Possible values: `0` (`Unknown`), `1` (`Closed`), `2` (`Open`).
+     * For more information, see https://docs.chain.link/data-streams/rwa-streams and https://docs.chain.link/data-streams/reference/report-schema-v4
+     */
+    struct ReportV4 {
+        bytes32 feedId; // The stream ID the report has data for.
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable.
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable.
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH).
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK.
+        uint32 expiresAt; // Latest timestamp where the report can be verified onchain.
+        int192 price; // DON consensus median benchmark price (8 or 18 decimals).
+        uint32 marketStatus; // The DON's consensus on whether the market is currently open.
+    }
+}

--- a/src/data-streams/interfaces/IRewardManager.sol
+++ b/src/data-streams/interfaces/IRewardManager.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IERC165} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/interfaces/IERC165.sol";
+
+interface IRewardManager is IERC165 {
+    function onFeePaid(FeePayment[] calldata payments, address payee) external;
+    function claimRewards(bytes32[] calldata poolIds) external;
+    function setFeeManager(address newFeeManager) external;
+
+    struct FeePayment {
+        bytes32 poolId;
+        uint192 amount;
+    }
+}

--- a/src/data-streams/interfaces/IVerifier.sol
+++ b/src/data-streams/interfaces/IVerifier.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IVerifier {
+    function verify(bytes calldata signedReport, address sender) external returns (bytes memory verifierResponse);
+    function activateConfig(bytes32 feedId, bytes32 configDigest) external;
+    function deactivateConfig(bytes32 feedId, bytes32 configDigest) external;
+    function activateFeed(bytes32 feedId) external;
+    function deactivateFeed(bytes32 feedId) external;
+}

--- a/src/data-streams/interfaces/IVerifierFeeManager.sol
+++ b/src/data-streams/interfaces/IVerifierFeeManager.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IERC165} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/interfaces/IERC165.sol";
+
+interface IVerifierFeeManager is IERC165 {
+    function processFee(bytes calldata payload, bytes calldata parameterPayload, address subscriber) external payable;
+    function processFeeBulk(bytes[] calldata payloads, bytes calldata parameterPayload, address subscriber)
+        external
+        payable;
+}

--- a/src/test/data-streams/ChainlinkDataStreamProvider.sol
+++ b/src/test/data-streams/ChainlinkDataStreamProvider.sol
@@ -1,0 +1,104 @@
+// Simplifed version of https://github.com/gmx-io/gmx-synthetics/blob/main/contracts/oracle/ChainlinkDataStreamProvider.sol used for testing purposes
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IChainlinkDataStreamVerifier {
+    /**
+     * @notice Verifies that the data encoded has been signed
+     * correctly by routing to the correct verifier, and bills the user if applicable.
+     * @param payload The encoded data to be verified, including the signed
+     * report.
+     * @param parameterPayload fee metadata for billing. For the current implementation this is just the abi-encoded fee token ERC-20 address
+     * @return verifierResponse The encoded report from the verifier.
+     */
+    function verify(bytes calldata payload, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes memory verifierResponse);
+}
+
+contract ChainlinkDataStreamProvider {
+    bytes32 public constant DATA_STREAM_ID = keccak256(abi.encode("DATA_STREAM_ID"));
+    bytes32 public constant CHAINLINK_PAYMENT_TOKEN = keccak256(abi.encode("CHAINLINK_PAYMENT_TOKEN"));
+
+    IChainlinkDataStreamVerifier public immutable verifier;
+
+    mapping(bytes32 => address) public addressValues;
+    mapping(bytes32 => bytes32) public bytes32Values;
+
+    // bid: min price, highest buy price
+    // ask: max price, lowest sell price
+    struct Report {
+        bytes32 feedId; // The feed ID the report has data for
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (WETH/ETH)
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK
+        uint32 expiresAt; // Latest timestamp where the report can be verified onchain
+        int192 price; // DON consensus median price, carried to 8 decimal places
+        int192 bid; // Simulated price impact of a buy order up to the X% depth of liquidity utilisation
+        int192 ask; // Simulated price impact of a sell order up to the X% depth of liquidity utilisation
+    }
+
+    error EmptyChainlinkPaymentToken();
+    error EmptyDataStreamFeedId(address token);
+    error InvalidDataStreamFeedId(address token, bytes32 reportFeedId, bytes32 expectedFeedId);
+    error InvalidDataStreamPrices(address token, int192 bid, int192 ask);
+    error InvalidDataStreamBidAsk(address token, int192 bid, int192 ask);
+
+    constructor(address _verifier, address linkTokenAddress) {
+        verifier = IChainlinkDataStreamVerifier(_verifier);
+        addressValues[CHAINLINK_PAYMENT_TOKEN] = linkTokenAddress;
+    }
+
+    function setBytes32(address token, bytes32 feedId) external {
+        bytes32Values[dataStreamIdKey(token)] = feedId;
+    }
+
+    // @dev key for data stream feed ID
+    // @param token the token to get the key for
+    // @return key for data stream feed ID
+    function dataStreamIdKey(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(DATA_STREAM_ID, token));
+    }
+
+    function getOraclePrice(address token, bytes memory data)
+        external
+        returns (address token_, int192 bid, int192 ask, uint32 timestamp)
+    {
+        bytes32 feedId = bytes32Values[dataStreamIdKey(token)];
+        if (feedId == bytes32(0)) {
+            revert EmptyDataStreamFeedId(token);
+        }
+
+        bytes memory payloadParameter = _getPayloadParameter();
+        bytes memory verifierResponse = verifier.verify(data, payloadParameter);
+
+        Report memory report = abi.decode(verifierResponse, (Report));
+
+        if (feedId != report.feedId) {
+            revert InvalidDataStreamFeedId(token, report.feedId, feedId);
+        }
+
+        if (report.bid <= 0 || report.ask <= 0) {
+            revert InvalidDataStreamPrices(token, report.bid, report.ask);
+        }
+
+        if (report.bid > report.ask) {
+            revert InvalidDataStreamBidAsk(token, report.bid, report.ask);
+        }
+
+        return (token, report.bid, report.ask, report.observationsTimestamp);
+    }
+
+    function _getPayloadParameter() internal view returns (bytes memory) {
+        // LINK token address
+        address feeToken = addressValues[CHAINLINK_PAYMENT_TOKEN];
+
+        if (feeToken == address(0)) {
+            revert EmptyChainlinkPaymentToken();
+        }
+
+        return abi.encode(feeToken);
+    }
+}

--- a/src/test/data-streams/ClientReportsVerifier.sol
+++ b/src/test/data-streams/ClientReportsVerifier.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
+
+library Common {
+    struct Asset {
+        address token;
+        uint256 amount;
+    }
+}
+
+interface IVerifierProxy {
+    function verify(bytes calldata payload, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes memory verifierResponse);
+
+    function verifyBulk(bytes[] calldata payloads, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes[] memory verifiedReports);
+
+    function s_feeManager() external view returns (address);
+}
+
+interface IFeeManager {
+    function getFeeAndReward(address subscriber, bytes memory unverifiedReport, address quoteAddress)
+        external
+        returns (Common.Asset memory, Common.Asset memory, uint256);
+
+    function i_linkAddress() external view returns (address);
+
+    function i_nativeAddress() external view returns (address);
+
+    function i_rewardManager() external view returns (address);
+}
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE FOR DEMONSTRATION PURPOSES.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+contract ClientReportsVerifier {
+    using SafeERC20 for IERC20;
+
+    error NothingToWithdraw();
+    error NotOwner(address caller);
+    error InvalidReportVersion(uint16 version);
+
+    struct ReportV3 {
+        bytes32 feedId; // The stream ID the report has data for.
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable.
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable.
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH).
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK.
+        uint32 expiresAt; // Latest timestamp where the report can be verified onchain.
+        int192 price; // DON consensus median price (8 or 18 decimals).
+        int192 bid; // Simulated price impact of a buy order up to the X% depth of liquidity utilisation (8 or 18 decimals).
+        int192 ask; // Simulated price impact of a sell order up to the X% depth of liquidity utilisation (8 or 18 decimals).
+    }
+
+    struct ReportV4 {
+        bytes32 feedId; // The stream ID the report has data for.
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable.
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable.
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (e.g., WETH/ETH).
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK.
+        uint32 expiresAt; // Latest timestamp where the report can be verified onchain.
+        int192 price; // DON consensus median benchmark price (8 or 18 decimals).
+        uint32 marketStatus; // The DON's consensus on whether the market is currently open.
+    }
+
+    IVerifierProxy public s_verifierProxy;
+
+    address private s_owner;
+    int192 public lastDecodedPrice;
+
+    event DecodedPrice(int192 price);
+
+    constructor(address _verifierProxy) {
+        s_owner = msg.sender;
+        s_verifierProxy = IVerifierProxy(_verifierProxy);
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != s_owner) revert NotOwner(msg.sender);
+        _;
+    }
+
+    function verifyReport(bytes memory unverifiedReport) external {
+        IFeeManager feeManager = IFeeManager(s_verifierProxy.s_feeManager());
+
+        address rewardManager = feeManager.i_rewardManager();
+
+        // Decode unverified report to extract report data
+        (, bytes memory reportData) = abi.decode(unverifiedReport, (bytes32[3], bytes));
+
+        // Extract report version from reportData
+        uint16 reportVersion = (uint16(uint8(reportData[0])) << 8) | uint16(uint8(reportData[1]));
+
+        // Validate report version
+        if (reportVersion != 3 && reportVersion != 4) {
+            revert InvalidReportVersion(uint8(reportVersion));
+        }
+
+        // Set the fee token address (LINK in this case)
+        address feeTokenAddress = feeManager.i_linkAddress();
+
+        // Calculate the fee required for report verification
+        (Common.Asset memory fee,,) = feeManager.getFeeAndReward(address(this), reportData, feeTokenAddress);
+
+        // Approve rewardManager to spend this contract's balance in fees
+        IERC20(feeTokenAddress).approve(rewardManager, fee.amount);
+
+        // Verify the report through the VerifierProxy
+        bytes memory verifiedReportData = s_verifierProxy.verify(unverifiedReport, abi.encode(feeTokenAddress));
+
+        // Decode verified report data into the appropriate Report struct based on reportVersion
+        if (reportVersion == 3) {
+            // v3 report schema
+            ReportV3 memory verifiedReport = abi.decode(verifiedReportData, (ReportV3));
+
+            // Log price from the verified report
+            emit DecodedPrice(verifiedReport.price);
+
+            // Store the price from the report
+            lastDecodedPrice = verifiedReport.price;
+        } else if (reportVersion == 4) {
+            // v4 report schema
+            ReportV4 memory verifiedReport = abi.decode(verifiedReportData, (ReportV4));
+
+            // Log price from the verified report
+            emit DecodedPrice(verifiedReport.price);
+
+            // Store the price from the report
+            lastDecodedPrice = verifiedReport.price;
+        }
+    }
+
+    function withdrawToken(address _beneficiary, address _token) external onlyOwner {
+        uint256 amount = IERC20(_token).balanceOf(address(this));
+
+        if (amount == 0) revert NothingToWithdraw();
+
+        IERC20(_token).safeTransfer(_beneficiary, amount);
+    }
+}

--- a/src/test/data-streams/ERC7412Compatible.sol
+++ b/src/test/data-streams/ERC7412Compatible.sol
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import {IERC165} from
+    "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.3/contracts/interfaces/IERC165.sol";
+import {OwnerIsCreator} from "@chainlink/contracts/src/v0.8/shared/access/OwnerIsCreator.sol";
+import {IERC20} from "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.0/contracts/interfaces/IERC20.sol";
+
+interface IRewardManager is IERC165 {
+    /**
+     * @notice Record the fee received for a particular pool
+     * @param payments array of structs containing pool id and amount
+     * @param payee the user the funds should be retrieved from
+     */
+    function onFeePaid(FeePayment[] calldata payments, address payee) external;
+
+    /**
+     * @notice Claims the rewards in a specific pool
+     * @param poolIds array of poolIds to claim rewards for
+     */
+    function claimRewards(bytes32[] calldata poolIds) external;
+
+    /**
+     * @notice Set the RewardRecipients and weights for a specific pool. This should only be called once per pool Id. Else updateRewardRecipients should be used.
+     * @param poolId poolId to set RewardRecipients and weights for
+     * @param rewardRecipientAndWeights array of each RewardRecipient and associated weight
+     */
+    function setRewardRecipients(bytes32 poolId, Common.AddressAndWeight[] calldata rewardRecipientAndWeights)
+        external;
+
+    /**
+     * @notice Updates a subset the reward recipients for a specific poolId. The collective weight of the recipients should add up to the recipients existing weights. Any recipients with a weight of 0 will be removed.
+     * @param poolId the poolId to update
+     * @param newRewardRecipients array of new reward recipients
+     */
+    function updateRewardRecipients(bytes32 poolId, Common.AddressAndWeight[] calldata newRewardRecipients) external;
+
+    /**
+     * @notice Pays all the recipients for each of the pool ids
+     * @param poolId the pool id to pay recipients for
+     * @param recipients array of recipients to pay within the pool
+     */
+    function payRecipients(bytes32 poolId, address[] calldata recipients) external;
+
+    /**
+     * @notice Sets the fee manager. This needs to be done post construction to prevent a circular dependency.
+     * @param newFeeManager address of the new verifier proxy
+     */
+    function setFeeManager(address newFeeManager) external;
+
+    /**
+     * @notice Gets a list of pool ids which have reward for a specific recipient.
+     * @param recipient address of the recipient to get pool ids for
+     * @param startIndex the index to start from
+     * @param endIndex the index to stop at
+     */
+    function getAvailableRewardPoolIds(address recipient, uint256 startIndex, uint256 endIndex)
+        external
+        view
+        returns (bytes32[] memory);
+
+    /**
+     * @notice The structure to hold a fee payment notice
+     * @param poolId the poolId receiving the payment
+     * @param amount the amount being paid
+     */
+    struct FeePayment {
+        bytes32 poolId;
+        uint192 amount;
+    }
+}
+
+interface IVerifierFeeManager is IERC165 {
+    /**
+     * @notice Handles fees for a report from the subscriber and manages rewards
+     * @param payload report to process the fee for
+     * @param parameterPayload fee payload
+     * @param subscriber address of the fee will be applied
+     */
+    function processFee(bytes calldata payload, bytes calldata parameterPayload, address subscriber) external payable;
+
+    /**
+     * @notice Processes the fees for each report in the payload, billing the subscriber and paying the reward manager
+     * @param payloads reports to process
+     * @param parameterPayload fee payload
+     * @param subscriber address of the user to process fee for
+     */
+    function processFeeBulk(bytes[] calldata payloads, bytes calldata parameterPayload, address subscriber)
+        external
+        payable;
+
+    /**
+     * @notice Sets the fee recipients according to the fee manager
+     * @param configDigest digest of the configuration
+     * @param rewardRecipientAndWeights the address and weights of all the recipients to receive rewards
+     */
+    function setFeeRecipients(bytes32 configDigest, Common.AddressAndWeight[] calldata rewardRecipientAndWeights)
+        external;
+}
+
+/*
+ * @title Common
+ * @author Michael Fletcher
+ * @notice Common functions and structs
+ */
+library Common {
+    // @notice The asset struct to hold the address of an asset and amount
+    struct Asset {
+        address assetAddress;
+        uint256 amount;
+    }
+
+    // @notice Struct to hold the address and its associated weight
+    struct AddressAndWeight {
+        address addr;
+        uint64 weight;
+    }
+
+    /**
+     * @notice Checks if an array of AddressAndWeight has duplicate addresses
+     * @param recipients The array of AddressAndWeight to check
+     * @return bool True if there are duplicates, false otherwise
+     */
+    function _hasDuplicateAddresses(Common.AddressAndWeight[] memory recipients) internal pure returns (bool) {
+        for (uint256 i = 0; i < recipients.length;) {
+            for (uint256 j = i + 1; j < recipients.length;) {
+                if (recipients[i].addr == recipients[j].addr) {
+                    return true;
+                }
+                unchecked {
+                    ++j;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        return false;
+    }
+}
+
+interface IVerifierProxy {
+    function verify(bytes calldata payload, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes memory verifierResponse);
+
+    function s_feeManager() external view returns (IVerifierFeeManager);
+}
+
+interface IFeeManager {
+    function getFeeAndReward(address subscriber, bytes memory report, address quoteAddress)
+        external
+        returns (Common.Asset memory, Common.Asset memory, uint256);
+
+    function i_linkAddress() external view returns (address);
+
+    function i_nativeAddress() external view returns (address);
+
+    function i_rewardManager() external view returns (address);
+}
+
+/**
+ * @title ERC-7412 Off-Chain Data Retrieval Contract
+ */
+interface IERC7412 {
+    /**
+     * @dev Emitted when an oracle is requested to provide data. Upon receipt of this error, a wallet client
+     * should automatically resolve the requested oracle data and call fulfillOracleQuery.
+     * @param oracleContract The address of the oracle contract (which is also the fulfillment contract).
+     * @param oracleQuery The query to be sent to the off-chain interface.
+     */
+    error OracleDataRequired(address oracleContract, bytes oracleQuery);
+
+    /**
+     * @dev Emitted when the recently posted oracle data requires a fee to be paid. Upon receipt of this error,
+     * a wallet client should attach the requested feeAmount to the most recently posted oracle data transaction
+     */
+    error FeeRequired(uint256 feeAmount);
+
+    /**
+     * @dev Returns a human-readable identifier of the oracle contract. This should map to a URL and API
+     * key on the client side.
+     * @return The oracle identifier.
+     */
+    function oracleId() external view returns (bytes32);
+
+    /**
+     * @dev Upon resolving the oracle query, the client should call this function to post the data to the
+     * blockchain.
+     * @param signedOffchainData The data that was returned from the off-chain interface, signed by the oracle.
+     */
+    function fulfillOracleQuery(bytes calldata signedOffchainData) external payable;
+}
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+contract DataStreamsERC7412Compatible is IERC7412, OwnerIsCreator {
+    struct BasicReport {
+        bytes32 feedId; // The feed ID the report has data for
+        uint32 validFromTimestamp; // Earliest timestamp for which price is applicable
+        uint32 observationsTimestamp; // Latest timestamp for which price is applicable
+        uint192 nativeFee; // Base cost to validate a transaction using the report, denominated in the chain’s native token (WETH/ETH)
+        uint192 linkFee; // Base cost to validate a transaction using the report, denominated in LINK
+        uint32 expiresAt; // Latest timestamp where the report can be verified on-chain
+        int192 price; // DON consensus median price, carried to 8 decimal places
+    }
+
+    struct LatestPriceData {
+        int192 price; // DON consensus median price, carried to 8 decimal places
+        uint32 expiresAt; // Latest timestamp where the report can be verified on-chain
+        uint32 cacheTimestamp; // The timestamp when the entry to the s_latestPrice mapping has been made
+    }
+
+    /**
+     * @notice The Chainlink Verifier Contract
+     * This contract verifies the signature from the DON to cryptographically guarantee that the report has not been altered
+     * from the time that the DON reached consensus to the point where you use the data in your application.
+     */
+    IVerifierProxy public verifier;
+
+    string public constant STRING_DATASTREAMS_FEEDLABEL = "feedIDs";
+    string public constant STRING_DATASTREAMS_QUERYLABEL = "timestamp";
+
+    mapping(bytes32 => LatestPriceData) public s_latestPrice;
+
+    event PriceUpdate(int192 indexed price, bytes32 indexed feedId);
+
+    /**
+     * @dev Value doesn't fit in an uint of `bits` size.
+     */
+    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
+    error FailedToWithdrawEth(address owner, address target, uint256 value);
+
+    constructor(address _verifier) {
+        verifier = IVerifierProxy(_verifier);
+    }
+
+    receive() external payable {}
+
+    /**
+     * @notice Emits an OracleDataRequired error when an oracle is requested to provide data
+     * @param feedId - Stream ID which can be found at https://docs.chain.link/data-streams/stream-ids
+     *                  For example, Basic ETH/USD price report is 0x00027bbaff688c906a3e20a34fe951715d1018d262a5b66e38eda027a674cd1b
+     */
+    function generate7412CompatibleCall(bytes32 feedId, uint32 stalenessTolerance) public view returns (int192) {
+        LatestPriceData memory latestPrice = s_latestPrice[feedId];
+        uint32 considerStaleAfter = latestPrice.cacheTimestamp + stalenessTolerance;
+
+        if (considerStaleAfter > toUint32(block.timestamp) && latestPrice.expiresAt > considerStaleAfter) {
+            return latestPrice.price;
+        }
+
+        bytes memory oracleQuery =
+            abi.encode(STRING_DATASTREAMS_FEEDLABEL, feedId, STRING_DATASTREAMS_QUERYLABEL, block.timestamp, "");
+
+        revert IERC7412.OracleDataRequired(address(this), oracleQuery);
+    }
+
+    function oracleId() external pure override returns (bytes32) {
+        return "CHAINLINK_DATA_STREAMS";
+    }
+
+    function fulfillOracleQuery(bytes calldata signedOffchainData) external payable override {
+        (, bytes memory reportData) = abi.decode(signedOffchainData, (bytes32[3], bytes));
+
+        // Handle billing
+        IFeeManager feeManager = IFeeManager(address(verifier.s_feeManager()));
+        IRewardManager rewardManager = IRewardManager(address(feeManager.i_rewardManager()));
+
+        // Fees can be paid in either LINK (i_linkAddress()) or native coin ERC20-wrapped version (i_nativeAddress())
+        address feeTokenAddress = feeManager.i_linkAddress();
+        (Common.Asset memory fee,,) = feeManager.getFeeAndReward(address(this), reportData, feeTokenAddress);
+
+        if (IERC20(feeTokenAddress).balanceOf(address(this)) < fee.amount) {
+            revert IERC7412.FeeRequired(fee.amount);
+        } else {
+            IERC20(feeTokenAddress).approve(address(rewardManager), fee.amount);
+        }
+
+        // Verify the report
+        bytes memory verifiedReportData = verifier.verify(signedOffchainData, abi.encode(feeTokenAddress));
+
+        // Decode verified report data into BasicReport struct
+        BasicReport memory verifiedReport = abi.decode(verifiedReportData, (BasicReport));
+
+        s_latestPrice[verifiedReport.feedId] = LatestPriceData({
+            price: verifiedReport.price,
+            expiresAt: verifiedReport.expiresAt,
+            cacheTimestamp: toUint32(block.timestamp)
+        });
+
+        // Log price from report
+        emit PriceUpdate(verifiedReport.price, verifiedReport.feedId);
+    }
+
+    /**
+     * OpenZeppelin Contracts (last updated v5.0.0) (utils/math/SafeCast.sol)
+     *
+     * @dev Returns the downcasted uint32 from uint256, reverting on
+     * overflow (when the input is greater than largest uint32).
+     *
+     * Counterpart to Solidity's `uint32` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 32 bits
+     */
+    function toUint32(uint256 value) internal pure returns (uint32) {
+        if (value > type(uint32).max) {
+            revert SafeCastOverflowedUintDowncast(32, value);
+        }
+        return uint32(value);
+    }
+
+    function withdraw(address beneficiary) public onlyOwner {
+        uint256 amount = address(this).balance;
+        (bool sent,) = beneficiary.call{value: amount}("");
+        if (!sent) revert FailedToWithdrawEth(msg.sender, beneficiary, amount);
+    }
+
+    function withdrawToken(address beneficiary, address token) public onlyOwner {
+        uint256 amount = IERC20(token).balanceOf(address(this));
+        IERC20(token).transfer(beneficiary, amount);
+    }
+}

--- a/test/e2e/data-streams/DataStreamsConsumerFork.t.sol
+++ b/test/e2e/data-streams/DataStreamsConsumerFork.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {DataStreamsLocalSimulatorFork, Register} from "../../../src/data-streams/DataStreamsLocalSimulatorFork.sol";
+import {ReportVersions} from "../../../src/data-streams/ReportVersions.sol";
+import {IERC20} from "@chainlink/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.8.0/contracts/interfaces/IERC20.sol";
+
+interface IVerifierProxy {
+    function verify(bytes calldata payload, bytes calldata parameterPayload)
+        external
+        payable
+        returns (bytes memory verifierResponse);
+
+    function s_feeManager() external view returns (address);
+}
+
+library Common {
+    struct Asset {
+        address token;
+        uint256 amount;
+    }
+}
+
+interface IFeeManager {
+    function getFeeAndReward(address subscriber, bytes memory unverifiedReport, address quoteAddress)
+        external
+        returns (Common.Asset memory, Common.Asset memory, uint256);
+
+    function i_linkAddress() external view returns (address);
+
+    function i_nativeAddress() external view returns (address);
+
+    function i_rewardManager() external view returns (address);
+}
+
+contract DataStreamsConsumerForkTest is Test {
+    bytes public UNVERIFIED_INPUT_REPORT =
+        hex"0006f9b553e393ced311551efd30d1decedb63d76ad41737462e2cdbbdff1578000000000000000000000000000000000000000000000000000000004b0b4006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000028001010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000120000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba7820000000000000000000000000000000000000000000000000000000067407f400000000000000000000000000000000000000000000000000000000067407f4000000000000000000000000000000000000000000000000000001b1fa2a2d6400000000000000000000000000000000000000000000000000016e76dd08b2c34000000000000000000000000000000000000000000000000000000006741d0c00000000000000000000000000000000000000000000000b5c654dd994866cb600000000000000000000000000000000000000000000000b5c6042e4f23a92c400000000000000000000000000000000000000000000000b5c7dc7c8e30df80000000000000000000000000000000000000000000000000000000000000000002f68eeb7e489bef244eb83d56e1b8af210a65363e5ad4407f374e5c06f46db98c36b4181b70329535011ba504fb8e09570c10a6de7f1f138cf322237c72cb0d650000000000000000000000000000000000000000000000000000000000000002648579956ffb863e4ea9470a87bb59b26e91ea893f96c2ab933786e531f2701a06d92b4e896a42d40d19a3b5ba1711d5f00bc262084d7afce44a5bbde3014fe5";
+
+    ReportVersions.ReportV3 public EXPECTED_REPORT = ReportVersions.ReportV3({
+        feedId: 0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782,
+        validFromTimestamp: 1732280128,
+        observationsTimestamp: 1732280128,
+        nativeFee: 29822686516800,
+        linkFee: 6446908323867700,
+        expiresAt: 1732366528,
+        price: 3353151968509396700000,
+        bid: 3353129257778281000000,
+        ask: 3353262200000000000000
+    });
+
+    DataStreamsLocalSimulatorFork dataStreamsLocalSimulatorFork;
+
+    uint256 arbitrumSepoliaForkId;
+    address alice;
+
+    function setUp() public {
+        string memory ARBITRUM_SEPOLIA_RPC_URL = vm.envString("ARBITRUM_SEPOLIA_RPC_URL");
+        uint256 BLOCK_NUMBER = 99556570;
+        arbitrumSepoliaForkId = vm.createSelectFork(ARBITRUM_SEPOLIA_RPC_URL, BLOCK_NUMBER);
+
+        alice = makeAddr("alice");
+
+        dataStreamsLocalSimulatorFork = new DataStreamsLocalSimulatorFork();
+    }
+
+    function preTestHook() public returns (IVerifierProxy, IFeeManager, address, bytes memory) {
+        assertEq(vm.activeFork(), arbitrumSepoliaForkId);
+
+        Register.NetworkDetails memory networkDetails = dataStreamsLocalSimulatorFork.getNetworkDetails(block.chainid);
+        IVerifierProxy verifierProxy = IVerifierProxy(networkDetails.verifierProxyAddress);
+        IFeeManager feeManager = IFeeManager(verifierProxy.s_feeManager());
+        address rewardManager = feeManager.i_rewardManager();
+
+        // Decode unverified report to extract report data
+        (, bytes memory reportData) = abi.decode(UNVERIFIED_INPUT_REPORT, (bytes32[3], bytes));
+
+        return (verifierProxy, feeManager, rewardManager, reportData);
+    }
+
+    function postTestHook(ReportVersions.ReportV3 memory verifiedReport) public {
+        assertEq(verifiedReport.feedId, EXPECTED_REPORT.feedId);
+        assertEq(verifiedReport.validFromTimestamp, EXPECTED_REPORT.validFromTimestamp);
+        assertEq(verifiedReport.observationsTimestamp, EXPECTED_REPORT.observationsTimestamp);
+        assertEq(verifiedReport.nativeFee, EXPECTED_REPORT.nativeFee);
+        assertEq(verifiedReport.linkFee, EXPECTED_REPORT.linkFee);
+        assertEq(verifiedReport.expiresAt, EXPECTED_REPORT.expiresAt);
+        assertEq(verifiedReport.price, EXPECTED_REPORT.price);
+        assertEq(verifiedReport.bid, EXPECTED_REPORT.bid);
+        assertEq(verifiedReport.ask, EXPECTED_REPORT.ask);
+    }
+
+    function test_forkPayWithLink() external {
+        (IVerifierProxy verifierProxy, IFeeManager feeManager, address rewardManager, bytes memory reportData) =
+            preTestHook();
+
+        address feeTokenAddress = feeManager.i_linkAddress();
+
+        (Common.Asset memory fee,,) = feeManager.getFeeAndReward(address(this), reportData, feeTokenAddress);
+
+        uint256 linkBalanceAliceBefore = IERC20(feeTokenAddress).balanceOf(alice);
+        dataStreamsLocalSimulatorFork.requestLinkFromFaucet(alice, fee.amount);
+
+        vm.startPrank(alice);
+
+        IERC20(feeTokenAddress).approve(rewardManager, fee.amount);
+
+        bytes memory verifiedReportData = verifierProxy.verify(UNVERIFIED_INPUT_REPORT, abi.encode(feeTokenAddress));
+        ReportVersions.ReportV3 memory verifiedReport = abi.decode(verifiedReportData, (ReportVersions.ReportV3));
+
+        vm.stopPrank();
+
+        uint256 linkBalanceAliceAfter = IERC20(feeTokenAddress).balanceOf(alice);
+        assertEq(linkBalanceAliceAfter, linkBalanceAliceBefore);
+
+        postTestHook(verifiedReport);
+    }
+
+    function test_forkPayWithNative() external {
+        (IVerifierProxy verifierProxy, IFeeManager feeManager,, bytes memory reportData) = preTestHook();
+
+        address feeTokenAddress = feeManager.i_nativeAddress();
+
+        (Common.Asset memory fee,,) = feeManager.getFeeAndReward(address(this), reportData, feeTokenAddress);
+
+        uint256 nativeBalanceAliceBefore = address(alice).balance;
+        dataStreamsLocalSimulatorFork.requestNativeFromFaucet(alice, fee.amount);
+
+        vm.startPrank(alice);
+
+        bytes memory verifiedReportData =
+            verifierProxy.verify{value: fee.amount}(UNVERIFIED_INPUT_REPORT, abi.encode(feeTokenAddress));
+
+        ReportVersions.ReportV3 memory verifiedReport = abi.decode(verifiedReportData, (ReportVersions.ReportV3));
+
+        vm.stopPrank();
+
+        uint256 nativeBalanceAliceAfter = address(alice).balance;
+        assertEq(nativeBalanceAliceAfter, nativeBalanceAliceBefore);
+
+        postTestHook(verifiedReport);
+    }
+}

--- a/test/smoke/data-streams/ChainlinkDataStreamProvider.t.sol
+++ b/test/smoke/data-streams/ChainlinkDataStreamProvider.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {
+    DataStreamsLocalSimulator,
+    MockVerifierProxy,
+    MockFeeManager,
+    LinkToken
+} from "@chainlink/local/src/data-streams/DataStreamsLocalSimulator.sol";
+import {MockReportGenerator} from "@chainlink/local/src/data-streams/MockReportGenerator.sol";
+
+import {ChainlinkDataStreamProvider} from "../../../src/test/data-streams/ChainlinkDataStreamProvider.sol";
+
+contract ChainlinkDataStreamProviderTest is Test {
+    DataStreamsLocalSimulator public dataStreamsLocalSimulator;
+    MockReportGenerator public mockReportGenerator;
+    MockFeeManager public mockFeeManager;
+
+    ChainlinkDataStreamProvider public consumer;
+    int192 public initialPrice;
+
+    function setUp() public {
+        dataStreamsLocalSimulator = new DataStreamsLocalSimulator();
+        (, LinkToken linkToken_,, MockVerifierProxy mockVerifierProxy_, MockFeeManager mockFeeManager_,) =
+            dataStreamsLocalSimulator.configuration();
+
+        mockFeeManager = mockFeeManager_;
+
+        initialPrice = 1 ether;
+        mockReportGenerator = new MockReportGenerator(initialPrice);
+
+        consumer = new ChainlinkDataStreamProvider(address(mockVerifierProxy_), address(linkToken_));
+    }
+
+    function test_smoke() public {
+        mockFeeManager.setMockDiscount(address(consumer), 1e18); // 1e18 => 100% discount on fees
+
+        int192 wantPrice = 200;
+        int192 wantBid = 100;
+        int192 wantAsk = 300;
+        mockReportGenerator.updatePriceBidAndAsk(wantPrice, wantBid, wantAsk);
+
+        bytes32 feedId = hex"0003777777777777777777777777777777777777777777777777777777777777";
+        address token = 0x7777777777777777777777777777777777777777;
+        consumer.setBytes32(token, feedId);
+
+        (bytes memory signedReportV3,) = mockReportGenerator.generateReportV3();
+
+        (address gotToken, int192 gotBid, int192 gotAsk, /*uint32 gotObservationsTimestamp*/ ) =
+            consumer.getOraclePrice(token, signedReportV3);
+
+        assertEq(gotToken, token);
+        assertEq(gotBid, wantBid);
+        assertEq(gotAsk, wantAsk);
+    }
+}

--- a/test/smoke/data-streams/ClientReportsVerifier.spec.ts
+++ b/test/smoke/data-streams/ClientReportsVerifier.spec.ts
@@ -1,0 +1,48 @@
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { ethers } from "hardhat";
+import { assert } from "chai";
+import { MockReportGenerator } from "../../../scripts/data-streams/MockReportGenerator";
+
+describe("ClientReportsVerifier", function () {
+
+    async function deploy() {
+        const localSimulatorFactory = await ethers.getContractFactory("DataStreamsLocalSimulator");
+        const localSimulator = await localSimulatorFactory.deploy();
+
+        const config: {
+            wrappedNative_: string;
+            linkToken_: string;
+            mockVerifier_: string;
+            mockVerifierProxy_: string;
+            mockFeeManager_: string;
+            mockRewardManager_: string;
+        } = await localSimulator.configuration();
+
+        const initialPrice = ethers.parseEther("1");
+        const mockReportGenerator = new MockReportGenerator(initialPrice);
+
+        const consumerFactory = await ethers.getContractFactory("ClientReportsVerifier");
+        const consumer = await consumerFactory.deploy(config.mockVerifierProxy_);
+
+        await mockReportGenerator.updateFees(ethers.parseEther("1"), ethers.parseEther("0.5"));
+
+        await localSimulator.requestLinkFromFaucet(consumer.target, ethers.parseEther("1"));
+
+        // const mockFeeManager = await ethers.getContractAt("MockFeeManager", config.mockFeeManager_);
+        // await mockFeeManager.setMockDiscount(consumer.target, ethers.parseEther("1")); // 1e18 => 100% discount on fees
+
+        return { consumer, initialPrice, mockReportGenerator };
+    }
+
+    it("should verify Data Streams report", async function () {
+        const { consumer, initialPrice, mockReportGenerator } = await loadFixture(deploy);
+
+        const { signedReport, report } = await mockReportGenerator.generateReportV3();
+
+        await consumer.verifyReport(signedReport);
+
+        const lastDecodedPrice = await consumer.lastDecodedPrice();
+        assert(lastDecodedPrice === initialPrice);
+    });
+});
+

--- a/test/smoke/data-streams/ClientReportsVerifier.t.sol
+++ b/test/smoke/data-streams/ClientReportsVerifier.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {
+    DataStreamsLocalSimulator,
+    MockVerifierProxy
+} from "@chainlink/local/src/data-streams/DataStreamsLocalSimulator.sol";
+import {MockReportGenerator} from "@chainlink/local/src/data-streams/MockReportGenerator.sol";
+
+import {ClientReportsVerifier} from "../../../src/test/data-streams/ClientReportsVerifier.sol";
+
+contract ClientReportsVerifierTest is Test {
+    DataStreamsLocalSimulator public dataStreamsLocalSimulator;
+    MockReportGenerator public mockReportGenerator;
+
+    ClientReportsVerifier public consumer;
+    int192 initialPrice;
+
+    function setUp() public {
+        dataStreamsLocalSimulator = new DataStreamsLocalSimulator();
+        (,,, MockVerifierProxy mockVerifierProxy_,,) = dataStreamsLocalSimulator.configuration();
+
+        initialPrice = 1 ether;
+        mockReportGenerator = new MockReportGenerator(initialPrice);
+
+        consumer = new ClientReportsVerifier(address(mockVerifierProxy_));
+    }
+
+    function test_smoke() public {
+        mockReportGenerator.updateFees(1 ether, 0.5 ether);
+        (bytes memory signedReportV3,) = mockReportGenerator.generateReportV3();
+
+        dataStreamsLocalSimulator.requestLinkFromFaucet(address(consumer), 1 ether);
+
+        consumer.verifyReport(signedReportV3);
+
+        int192 lastDecodedPrice = consumer.lastDecodedPrice();
+        assertEq(lastDecodedPrice, initialPrice);
+    }
+}

--- a/test/smoke/data-streams/ERC7412Compatible.t.sol
+++ b/test/smoke/data-streams/ERC7412Compatible.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {
+    DataStreamsLocalSimulator,
+    MockVerifierProxy
+} from "@chainlink/local/src/data-streams/DataStreamsLocalSimulator.sol";
+import {MockReportGenerator} from "@chainlink/local/src/data-streams/MockReportGenerator.sol";
+
+import {DataStreamsERC7412Compatible} from "../../../src/test/data-streams/ERC7412Compatible.sol";
+
+contract ERC7412CompatibleTest is Test {
+    DataStreamsLocalSimulator public dataStreamsLocalSimulator;
+    MockReportGenerator public mockReportGenerator;
+
+    DataStreamsERC7412Compatible public consumer;
+
+    string public constant STRING_DATASTREAMS_FEEDLABEL = "feedIDs";
+    string public constant STRING_DATASTREAMS_QUERYLABEL = "timestamp";
+
+    function setUp() public {
+        dataStreamsLocalSimulator = new DataStreamsLocalSimulator();
+        (,,, MockVerifierProxy mockVerifierProxy_,,) = dataStreamsLocalSimulator.configuration();
+
+        int192 initialPrice = 1 ether;
+        mockReportGenerator = new MockReportGenerator(initialPrice);
+
+        consumer = new DataStreamsERC7412Compatible(address(mockVerifierProxy_));
+    }
+
+    function test_smoke() public {
+        mockReportGenerator.updateFees(1 ether, 0.5 ether);
+        dataStreamsLocalSimulator.requestLinkFromFaucet(address(consumer), 0.5 ether);
+
+        bytes32 feedId = hex"0002777777777777777777777777777777777777777777777777777777777777";
+        uint32 stalenessTolerance = 5 minutes;
+
+        try consumer.generate7412CompatibleCall(feedId, stalenessTolerance) {}
+        catch (bytes memory lowLevelData) {
+            if (bytes4(abi.encodeWithSignature("OracleDataRequired(address,bytes)")) == bytes4(lowLevelData)) {
+                uint256 length = lowLevelData.length;
+                bytes memory revertData = new bytes(length - 4);
+                for (uint256 i = 4; i < length; ++i) {
+                    revertData[i - 4] = lowLevelData[i];
+                }
+
+                (address oracleContract, bytes memory oracleQuery) = abi.decode(revertData, (address, bytes));
+                assertEq(oracleContract, address(consumer));
+
+                (, bytes32 revertedFeedId,,,) = abi.decode(oracleQuery, (string, bytes32, string, uint256, string));
+                assertEq(feedId, revertedFeedId);
+
+                (bytes memory signedReportV2,) = mockReportGenerator.generateReportV2();
+
+                consumer.fulfillOracleQuery(signedReportV2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* feat: Add Mock Data Feeds contracts

* feat: Add MockOffchainAggregator contract that expose minAnswer and maxAnswer functions. Add functionality to MockV3Aggregator to change underlying aggregator

* chore: Forge install @chainlink/contracts@v1.1.1

* feat: Add mock data feeds smoke test

* chore: List upcoming release in Changelog

* feat: Add unit tests for mock data feeds contracts

* feat: Add smoke test for mock data feeds using Hardhat

* feat: Add forking test example and prepare for beta release

* Support for CCIP v1.5 and preparing for 0.2.2-beta release (#19)

* feat: Add new changes to support CCIP v1.5 version

* forge: Update ccip

* chore: Add CCIP v1.5 config details to Register for all available testnet lanes. Prepare for 0.2.2-beta.0 release (#21)

* fix: Use the latest version of EVM2EVMOffRamp contract in the switchChainAndRouteMessage function of CCIPLocalSimulatorFork (#23)

* chore: Prepare repo for the 0.2.2 release

- Bump @chainlink/contracts-ccip to v1.5.0
- Delete DOCUMENTATION.md and related assets, and point to official documentation at README
- Update CHANGELOG

* Support for Chainlink Data Streams (#25)

* feat: Add mock data streams contracts

* feat: smoke test data streams in local mode in Foundry with docs examples

* feat: Add GMX-like test example

* feat: Add DataStreamsLocalSimulatorFork implemented in both Solidity and JavaScript

* feat: Add MockReportGenerator.js to support local mode in Hardhat; Support Forking mode in Hardhat

* chore: Prepare for 0.2.4-beta release

* chore: Generate docs artifacts

* chore: Include JavaScript Data Strems scripts into package.json

* Update README to include installation instructions for Foundry (soldeer) with chainlink-local versioning (#31)



* Data Streams fixes - v0.2.4-beta.0 release candidate (#34)

* chore: Bumped @chainlink/contracts to 1.3.0. Started returning raw report structs from generateReportV- functions which is handful for tests

* chore: Generate docs artifacts for this adjustment

* Fix year in CHANGELOG (#35)

* chore: Bumped @chainlink/contracts to 1.3.0. Started returning raw report structs from generateReportV- functions which is handful for tests

* chore: Generate docs artifacts for this adjustment

* fix: Year should be 2025 instead of 2024

* fix: Fix incorrect import path (#36)

* fix: Fix incorrect import path

* chore: Prepared changelog and package.json for v0.2.4-beta.1 release

* chore: Prepare for 0.2.4 release

---------